### PR TITLE
Make intensional and extensional DBs mutually exclusive

### DIFF
--- a/neurolang/expression_walker.py
+++ b/neurolang/expression_walker.py
@@ -131,22 +131,6 @@ class ExpressionWalker(PatternWalker):
                 for k in expression.kwargs
             )
         ):
-            functor_type, functor_value = get_type_and_value(functor)
-
-            if functor_type is not ToBeInferred:
-                if not is_subtype(functor_type, typing.Callable):
-                    raise NeuroLangTypeException(
-                        f'Function {functor} is not of callable type'
-                    )
-            else:
-                if (
-                    isinstance(functor, Constant) and
-                    not callable(functor_value)
-                ):
-                    raise NeuroLangTypeException(
-                        f'Function {functor} is not of callable type'
-                    )
-
             result = functor(*args, **kwargs)
             return self.walk(result)
         else:

--- a/neurolang/symbols_and_types.py
+++ b/neurolang/symbols_and_types.py
@@ -124,13 +124,20 @@ class TypedSymbolTable(collections.MutableMapping):
             ret = ret | self.enclosing_scope.types()
         return ret
 
-    def symbols_by_type(self, type_):
+    def symbols_by_type(self, type_, include_subtypes=True):
+        ret = dict()
         if self.enclosing_scope is not None:
-            ret = self.enclosing_scope.symbols_by_type(type_)
-        else:
-            ret = dict()
+            ret.update(self.enclosing_scope.symbols_by_type(type_))
 
-        ret.update(self._symbols_by_type[type_])
+        for t in self.types():
+            if (
+                t is type_ or (
+                    include_subtypes and
+                    t is not ToBeInferred and is_subtype(t, type_)
+                )
+            ):
+                ret.update(self._symbols_by_type[t])
+
         return ret
 
     def create_scope(self):

--- a/neurolang/tests/test_datalog_naive.py
+++ b/neurolang/tests/test_datalog_naive.py
@@ -41,8 +41,8 @@ def test_facts_constants():
     dl.walk(f1)
 
     assert 'Q' in dl.symbol_table
-    assert isinstance(dl.symbol_table['Q'], ExpressionBlock)
-    fact_set = dl.symbol_table['Q'].expressions[0]
+    assert isinstance(dl.symbol_table['Q'], Constant[AbstractSet])
+    fact_set = dl.symbol_table['Q']
     assert isinstance(fact_set, Constant)
     assert is_subtype(fact_set.type, AbstractSet)
     assert {C_((C_(1), C_(2)))} == fact_set.value
@@ -219,6 +219,7 @@ def test_extensional_database():
     dl = Datalog()
 
     Q = S_('Q')
+    R0 = S_('R0')
     R = S_('R')
     T = S_('T')
     x = S_('x')
@@ -230,10 +231,11 @@ def test_extensional_database():
         T_(Q(C_(1), C_(2))),
         T_(Q(C_(1), C_(4))),
         T_(Q(C_(2), C_(4))),
-        T_(R(C_('a'), C_(1), C_(3))),
+        T_(R0(C_('a'), C_(1), C_(3))),
     ))
 
     intensional = ExpressionBlock((
+        St_(R(x, y, z), R0(x, y, z)),
         St_(R(x, y, z), Q(x, y) & Q(y, z)),
         St_(T(x, z), Q(x, y) & Q(y, z)),
     ))
@@ -242,7 +244,7 @@ def test_extensional_database():
 
     edb = dl.extensional_database()
 
-    assert edb.keys() == {'R', 'Q'}
+    assert edb.keys() == {'R0', 'Q'}
 
     assert edb['Q'] == C_(frozenset((
         C_((C_(1), C_(1))),
@@ -251,14 +253,14 @@ def test_extensional_database():
         C_((C_(2), C_(4))),
     )))
 
-    assert edb['R'] == C_(frozenset((
+    assert edb['R0'] == C_(frozenset((
         C_((C_('a'), C_(1), C_(3))),
     )))
 
     dl.walk(intensional)
     edb = dl.extensional_database()
 
-    assert edb.keys() == {'R', 'Q'}
+    assert edb.keys() == {'R0', 'Q'}
 
     assert edb['Q'] == C_(frozenset((
         C_((C_(1), C_(1))),
@@ -267,7 +269,7 @@ def test_extensional_database():
         C_((C_(2), C_(4))),
     )))
 
-    assert edb['R'] == C_(frozenset((
+    assert edb['R0'] == C_(frozenset((
         C_((C_('a'), C_(1), C_(3))),
     )))
 

--- a/neurolang/tests/test_typing.py
+++ b/neurolang/tests/test_typing.py
@@ -64,7 +64,7 @@ def test_subclass():
         expressions.Constant[int], expressions.Constant[typing.AbstractSet]
     )
 
-    
+
 def test_replace_subtype():
     assert (
         typing.Set is symbols_and_types.replace_type_variable(
@@ -206,7 +206,8 @@ def test_TypedSymbolTable():
     assert 's3' in st
     assert st['s3'] == s3
     assert st.symbols_by_type(s1.type) == {'s1': s1, 's2': s2}
-    assert st.symbols_by_type(s3.type) == {'s3': s3}
+    assert st.symbols_by_type(s3.type, False) == {'s3': s3}
+    assert st.symbols_by_type(s3.type, True) == {'s1': s1, 's2': s2, 's3': s3}
 
     del st['s1']
     assert len(st) == 2


### PR DESCRIPTION
Make EDB and IDB disjoint leads to simpler code in the resolutions without losing expressive power. 
Needed some minor changes to the expression and walking infrastructure that were performed.