### PR TITLE
Small changes in the Expression framework to speed it up

### DIFF
--- a/neurolang/expression_walker.py
+++ b/neurolang/expression_walker.py
@@ -91,7 +91,7 @@ def expression_iterator(expression, include_level=False, dfs=True):
 
 class PatternWalker(PatternMatcher):
     def walk(self, expression):
-        logging.debug(f"walking {expression}")
+        logging.debug("walking %(expression)s", {'expression': expression})
         if isinstance(expression, tuple):
             result = [
                 self.walk(e)


### PR DESCRIPTION
* Changes to the use of logger to prevent `repr` to be called when logging is not required.
* Reducing the use of `inspect.signature` which is surprisingly slow.
* Small tune-ups