### PR TITLE
Basic logic in Neurosynth queries

### DIFF
--- a/neurolang/frontend/neurosynth_utils.py
+++ b/neurolang/frontend/neurosynth_utils.py
@@ -1,7 +1,10 @@
 import logging
 import os
-from ..regions import region_set_from_masked_data
+
 from pkg_resources import resource_exists, resource_filename
+
+from ..regions import region_set_from_masked_data
+
 try:
     import neurosynth as ns
 except ModuleNotFoundError:
@@ -9,6 +12,10 @@ except ModuleNotFoundError:
 
 
 class NeuroSynthHandler(object):
+    """
+    Class for the management of data provided by neurosynth.
+    """
+
     def __init__(self, ns_dataset=None):
         self._dataset = ns_dataset
 
@@ -18,15 +25,27 @@ class NeuroSynthHandler(object):
         frequency_threshold=0.05,
         q=0.01,
         prior=0.5,
-        image_type=None
+        image_type=None,
     ):
+        """
+        Method that allows to obtain the activations related to
+        a series of terms. The terms can be entered in the following formats:
+
+        String: All expressions allowed in neurosynth. It can be
+        a term, a simple logical expression, for example: (reward* | pain*).
+
+        Iterable: A list of terms that will be calculated as a disjunction.
+        This case does not support logical expressions.
+        """
         if image_type is None:
-            image_type = f'association-test_z_FDR_{q}'
+            image_type = f"association-test_z_FDR_{q}"
 
         if self._dataset is None:
             dataset = self.ns_load_dataset()
             self._dataset = dataset
-        if isinstance(terms, list):
+        if not isinstance(terms, types.StringTypes) and isinstance(
+            term, collections.Iterable
+        ):
             studies_ids = self._dataset.get_studies(
                 features=terms, frequency_threshold=frequency_threshold
             )
@@ -45,17 +64,17 @@ class NeuroSynthHandler(object):
     def ns_load_dataset(self):
 
         if resource_exists(
-            'neurolang.frontend', 'neurosynth_data/dataset.pkl'
+            "neurolang.frontend", "neurosynth_data/dataset.pkl"
         ):
             file = resource_filename(
-                'neurolang.frontend', 'neurosynth_data/dataset.pkl'
+                "neurolang.frontend", "neurosynth_data/dataset.pkl"
             )
             dataset = ns.Dataset.load(file)
         else:
-            path = resource_filename('neurolang.frontend', 'neurosynth_data')
+            path = resource_filename("neurolang.frontend", "neurosynth_data")
             logging.info(
-                f'Downloading neurosynth database'
-                f' and features in path: {path}'
+                f"Downloading neurosynth database"
+                f" and features in path: {path}"
             )
             dataset = self.download_ns_dataset(path)
 
@@ -66,7 +85,7 @@ class NeuroSynthHandler(object):
         if not os.path.exists(path):
             os.makedirs(path)
         ns.dataset.download(path=path, unpack=True)
-        dataset = ns.Dataset(os.path.join(path, 'database.txt'))
-        dataset.add_features(os.path.join(path, 'features.txt'))
-        dataset.save(os.path.join(path, 'dataset.pkl'))
+        dataset = ns.Dataset(os.path.join(path, "database.txt"))
+        dataset.add_features(os.path.join(path, "features.txt"))
+        dataset.save(os.path.join(path, "dataset.pkl"))
         return dataset


### PR DESCRIPTION
Bug fixed. Now we can use basic logical operations in neurosynth queries.
For example, 'pain* | noxious | nocicept*' in now allowed.