### PR TITLE
Exclude the last pandas mayor version from the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy
 scipy
 nibabel
-pandas>=0.23.4
+pandas>=0.23.4,<1.0.0
 tatsu
 neurosynth==0.3.7
 matplotlib


### PR DESCRIPTION
The last pandas mayor version (1.0.0) deprecated many methods. I think that the only one causing trouble because it was missing was `DataFrame.to_dense()`, but a quick solution was to just exclude that version in the requirements.