### PR TITLE
Fix fresh symbol generator having multiple repeated sequences.

### DIFF
--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -393,9 +393,9 @@ class Symbol(NonConstant):
 
     @classmethod
     def fresh(cls):
-        if not hasattr(cls, '_fresh_generator_'):
-            cls._fresh_generator_ = cls._fresh_generator()
-        new_symbol = next(cls._fresh_generator_)
+        if not hasattr(Symbol, '_fresh_generator_'):
+            Symbol._fresh_generator_ = Symbol._fresh_generator()
+        new_symbol = next(Symbol._fresh_generator_)
         if cls.type is not typing.Any:
             new_symbol = new_symbol.cast(cls.type)
         return new_symbol

--- a/neurolang/tests/test_expressions.py
+++ b/neurolang/tests/test_expressions.py
@@ -56,6 +56,19 @@ def test_fresh_symbol():
     assert s1 != s2 and s2 != s3 and s3.type is int
 
 
+def test_fresh_symbol_2():
+    # Reset sequence generators as if the program just started
+    if hasattr(S_, "_fresh_generator_"):
+        del S_._fresh_generator_
+    if hasattr(S_[str], "_fresh_generator_"):
+        del S_[str]._fresh_generator_
+
+    s2 = S_[str].fresh()
+    s1 = S_.fresh()
+
+    assert s1.name != s2.name
+
+
 def evaluate(expression, **kwargs):
     ebe = Evaluator()
     for k, v in kwargs.items():


### PR DESCRIPTION
There is a problem with repeated fresh symbols. It was a problem of each subtype having it's own generator, but it only occurred in odd situations. 

For example, the next code works as expected:
```python
>>> Symbol.fresh()
S{fresh_00000000: Unknown}
>>> Symbol[int].fresh()
S{fresh_00000001: int}
```

But if I call it in reversed order it was internally generating two sequences:
```python
>>> Symbol[int].fresh()
S{fresh_00000000: int}
>>> Symbol.fresh()
S{fresh_00000000: Unknown}
```

The problem is that on the first call `_fresh_generator_` is still not set and a new one is created but in the `Symbol[int]` class. Then `Symbol` does not know about that and creates one of his own, yielding repeated numbers.

I've changed the generator creation and access to use the `Symbol` class instead of `cls`. That way there is always a unique generator.