### PR TITLE
Improved frontend help and inspection

### DIFF
--- a/neurolang/frontend/query_resolution.py
+++ b/neurolang/frontend/query_resolution.py
@@ -35,7 +35,7 @@ class QueryBuilderBase:
         if isinstance(symbol_name, Expression):
             symbol_name = symbol_name.expression.name
         if symbol_name not in self.symbol_table:
-            raise ValueError('')
+            raise ValueError(f'Symbol {symbol_name} not defined')
         return Symbol(self, symbol_name)
 
     def __getitem__(self, symbol_name):
@@ -410,6 +410,14 @@ class QuerySymbolsProxy:
 
     def __contains__(self, symbol):
         return symbol in self._query_builder.symbol_table
+
+    def __iter__(self):
+        return iter(
+            sorted(set(
+                s.name for s in
+                self._query_builder.symbol_table
+            ))
+        )
 
     def __len__(self):
         return len(self._query_builder.symbol_table)

--- a/neurolang/frontend/query_resolution_expressions.py
+++ b/neurolang/frontend/query_resolution_expressions.py
@@ -8,6 +8,7 @@ from .. import neurolang as nl
 from ..expression_pattern_matching import NeuroLangPatternMatchingNoMatch
 from ..expression_walker import (ExpressionWalker, ReplaceExpressionsByValues,
                                  add_match)
+from ..type_system import is_leq_informative
 from ..utils import RelationalAlgebraFrozenSet
 
 
@@ -91,6 +92,22 @@ class Expression(object):
         return Operation(
             self.query_builder, new_expression, self, (name,)
         )
+
+    def help(self):
+        expression = self.expression
+        if isinstance(expression, nl.Constant):
+            if is_leq_informative(expression.type, Callable):
+                return help(expression.value)
+            elif is_leq_informative(expression.type, AbstractSet):
+                return "Set of tuples"
+            else:
+                return "Constant value"
+        elif isinstance(expression, nl.FunctionApplication):
+            return "Evaluation of function to parameters"
+        elif isinstance(expression, nl.Symbol):
+            return "Unlinked symbol"
+        else:
+            return "Help not defined yet"
 
 
 binary_operations = (
@@ -339,6 +356,10 @@ class Symbol(Expression):
                 return self._rsbv.walk(constant)
             except NeuroLangPatternMatchingNoMatch:
                 raise ValueError("Expression doesn't have a python value")
+
+    @property
+    def parameter_names(self):
+        return self.query_builder.parameter_names(self)
 
 
 class Query(Expression):

--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -368,6 +368,24 @@ def test_neurolange_dl_get_param_names():
     assert neurolang.predicate_parameter_names('q') == ('0', '1')
     assert neurolang.predicate_parameter_names(q) == ('0', '1')
     assert neurolang.predicate_parameter_names(r) == ('x',)
+    assert neurolang.symbols[r].predicate_parameter_names == ('x',)
+    assert r[x].help() is not None
+
+
+def test_neurolang_dl_datalog_code_list_symbols():
+    neurolang = frontend.NeurolangDL()
+    original_symbols = set(neurolang.symbols)
+    neurolang.execute_datalog_program('''
+    A(4, 5)
+    A(5, 6)
+    A(6, 5)
+    B(x,y) :- A(x, y)
+    B(x,y) :- B(x, z),A(z, y)
+    C(x) :- B(x, y), y == 5
+    D("x")
+    ''')
+
+    assert set(neurolang.symbols) == {'A', 'B', 'C', 'D'} | original_symbols
 
 
 def test_neurolang_dl_datalog_code():


### PR DESCRIPTION
Three frontend improvements:
let `nl` be a `NeurolangDL` instance:
* `iter(nl.symbols)` iterates over all symbol names, much as a `dict` instance.
* `s = nl.symbols['s']`, so `s` is a symbol. Then `s.help()` provides help for the symbol
* `s.parameter_names` provides a tuple with the names of the parameters for a result set much as `nl.predicate_parameter_names[s]`. Intended for column naming.