### PR TITLE
Cardinality constraints

### DIFF
--- a/neurolang/datalog/ontologies_parser.py
+++ b/neurolang/datalog/ontologies_parser.py
@@ -226,7 +226,7 @@ class OntologyParser:
         )
 
         warnings.warn(
-            f"""The restriction minCardinality cannot be 
+            f"""The restriction minCardinality cannot be
             parsed for {restricted_node}."""
         )
 
@@ -255,7 +255,7 @@ class OntologyParser:
         )
 
         warnings.warn(
-            f"""The restriction maxCardinality cannot be 
+            f"""The restriction maxCardinality cannot be
             parsed for {restricted_node}"""
         )
 
@@ -288,7 +288,7 @@ class OntologyParser:
         )
 
         warnings.warn(
-            f"""The restriction cardinality cannot be 
+            f"""The restriction cardinality cannot be
             parsed for {restricted_node}"""
         )
 


### PR DESCRIPTION
Considering that cardinality constraints cannot be parsed by Datalog and Xrewriter, I changed the warning message to make it clearer.

The other option would be to delete the cardinality processing function, avoiding the warnings. Any suggestions?