### PR TITLE
Cleaner constraints

### DIFF
--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -98,7 +98,6 @@ class NeurolangPDL(QueryBuilderDatalog):
             RegionFrontendCPLogicSolver(), chase_class=chase_class
         )
         self.probabilistic_solver = probabilistic_solver
-        self.ontology_loaded = False
 
     def load_ontology(
         self,
@@ -125,8 +124,6 @@ class NeurolangPDL(QueryBuilderDatalog):
         self.program_ir.add_extensional_predicate_from_tuples(
             onto.get_pointers_symbol(), d_pred[onto.get_pointers_symbol()]
         )
-
-        self.ontology_loaded = True
 
     @property
     def current_program(self) -> List[fe.Expression]:
@@ -319,7 +316,7 @@ class NeurolangPDL(QueryBuilderDatalog):
         return solution
 
     def _solve_deterministic_stratum(self, det_idb):
-        if self.ontology_loaded:
+        if '__constraints__' in self.symbol_table:
             eB = self._rewrite_program_with_ontology(det_idb)
             det_idb = Union(det_idb.formulas + eB.formulas)
         chase = self.chase_class(self.program_ir, rules=det_idb)

--- a/neurolang/frontend/tests/test_probabilistic_frontend.py
+++ b/neurolang/frontend/tests/test_probabilistic_frontend.py
@@ -528,3 +528,39 @@ def test_result_query_relation_correct_column_names():
         solution = nl.solve_all()
     assert all(name in solution for name in ["climbs", "person", "lives_in"])
     assert solution["climbs"].columns == ("p", "PROB", "city")
+
+
+def test_add_constraints_and_rewrite():
+    nl = ProbabilisticFrontend()
+
+    nl.add_tuple_set(
+        [
+            ("neurolang"),
+        ],
+        name="project",
+    )
+
+    nl.add_tuple_set(
+        [
+            ("neurolang", "db"),
+            ("neurolang", "logic"),
+        ],
+        name="inArea",
+    )
+
+    with nl.scope as e:
+        nl.add_constraint(
+            e.project[e.x] & e.inArea[e.x, e.y], 
+            e.hasCollaborator[e.z, e.y, e.x]
+        )
+
+        e.p[e.b] = (
+            e.hasCollaborator[e.a, 'db', e.b]
+        )
+        res = nl.solve_all()
+
+
+    assert list(res['p'])[0] == ('neurolang',)
+
+
+


### PR DESCRIPTION
- [x] Create operation to add constraints from the frontend without the need for ontologies.
- [x] Delete the parsed ontology flag used to indicate that rewriting is necessary.
- [x] Running the rewrite algorithm when there are constraints on the database.