### PR TITLE
Probabilistic Choice Self-Join resolution through unification

### DIFF
--- a/neurolang/probabilistic/expression_processing.py
+++ b/neurolang/probabilistic/expression_processing.py
@@ -350,6 +350,11 @@ def lift_optimization_for_choice_predicates(query, program):
             unifier = UnifyVariableEqualities()
             rule = Implication(Symbol.fresh()(tuple()), query)
             query = unifier.walk(rule).antecedent
+            # keep head variable equalities to prevent the rule from becoming
+            # invalid due to a head variable not occurring in the antecedent
+            # by keeping these variable equalities, we make sure that the
+            # logical semantic of the rule is maintained (without modifying the
+            # query's head)
             kept_equalities = Conjunction(
                 (
                     eq

--- a/neurolang/probabilistic/expression_processing.py
+++ b/neurolang/probabilistic/expression_processing.py
@@ -350,11 +350,6 @@ def lift_optimization_for_choice_predicates(query, program):
             unifier = UnifyVariableEqualities()
             rule = Implication(Symbol.fresh()(tuple()), query)
             query = unifier.walk(rule).antecedent
-            # keep head variable equalities to prevent the rule from becoming
-            # invalid due to a head variable not occurring in the antecedent
-            # by keeping these variable equalities, we make sure that the
-            # logical semantic of the rule is maintained (without modifying the
-            # query's head)
             kept_equalities = Conjunction(
                 (
                     eq

--- a/neurolang/probabilistic/expression_processing.py
+++ b/neurolang/probabilistic/expression_processing.py
@@ -247,23 +247,23 @@ def construct_within_language_succ_result(provset, rule):
     return Constant[AbstractSet](provset.value.projection(*proj_cols))
 
 
-def group_preds_by_pred_symb(predicates, filter_set=None):
+def group_preds_by_functor(predicates, filter_set=None):
     """
-    Group predicates by their predicate symbol.
+    Group predicates by their functor.
 
-    An optional filter set of predicate symbols can be passed to only return
-    the ones in the set.
+    An optional filter set of functors can be passed to only return the ones in
+    the set.
 
     Parameters
     ----------
     predicates : iterable of predicates
         Predicates that should be grouped.
-    filter_set : set of predicate symbols (optional)
-        Predicate symbols to consider.
+    filter_set : set of functors (optional)
+        Functors to consider.
 
     Returns
     -------
-    dict of predicate symbol to set of predicates
+    dict of functors to set of predicates
 
     """
     grouped = collections.defaultdict(set)
@@ -297,7 +297,7 @@ def get_probchoice_variable_equalities(predicates, pchoice_pred_symbs):
     P(y)` can only be true if `x == y`.
 
     """
-    grouped_pchoice_preds = group_preds_by_pred_symb(
+    grouped_pchoice_preds = group_preds_by_functor(
         predicates, pchoice_pred_symbs
     )
     eq_set = set()

--- a/neurolang/probabilistic/expression_processing.py
+++ b/neurolang/probabilistic/expression_processing.py
@@ -1,5 +1,4 @@
 import collections
-import operator as op
 from typing import AbstractSet, Iterable
 
 import numpy

--- a/neurolang/probabilistic/expression_processing.py
+++ b/neurolang/probabilistic/expression_processing.py
@@ -6,6 +6,8 @@ import numpy
 
 from ..datalog import WrappedRelationalAlgebraSet
 from ..datalog.expression_processing import (
+    UnifyVariableEqualities,
+    conjunct_formulas,
     extract_logic_predicates,
     iter_disjunction_or_implication_rules,
     reachable_code,
@@ -345,6 +347,17 @@ def lift_optimization_for_choice_predicates(query, program):
             added_equalities.append(eq(x, y))
         if len(added_equalities) > 0:
             query = Conjunction(query.formulas + tuple(added_equalities))
+            unifier = UnifyVariableEqualities()
+            rule = Implication(Symbol.fresh()(tuple()), query)
+            query = unifier.walk(rule).antecedent
+            kept_equalities = Conjunction(
+                (
+                    eq
+                    for eq in added_equalities
+                    if any(arg not in query._symbols for arg in eq.args)
+                )
+            )
+            query = conjunct_formulas(query, kept_equalities)
     return query
 
 

--- a/neurolang/probabilistic/tests/test_expression_processing.py
+++ b/neurolang/probabilistic/tests/test_expression_processing.py
@@ -6,7 +6,7 @@ from ...logic import Union
 from ..expression_processing import (
     add_to_union,
     get_probchoice_variable_equalities,
-    group_preds_by_pred_symb,
+    group_preds_by_functor,
 )
 
 P = Symbol("P")
@@ -82,8 +82,8 @@ def test_get_probchoice_variable_equalities():
 
 def test_group_preds_by_pred_symb():
     predicates = [P(x, y), Q(x)]
-    grouped = group_preds_by_pred_symb(predicates, filter_set={Q})
+    grouped = group_preds_by_functor(predicates, filter_set={Q})
     assert grouped == {Q: {Q(x)}}
     predicates = [P(x, y), Q(x)]
-    grouped = group_preds_by_pred_symb(predicates, filter_set=set())
+    grouped = group_preds_by_functor(predicates, filter_set=set())
     assert grouped == dict()

--- a/neurolang/probabilistic/tests/test_probabilistic_solvers.py
+++ b/neurolang/probabilistic/tests/test_probabilistic_solvers.py
@@ -701,10 +701,12 @@ def test_repeated_variable_with_constant_in_head(solver):
         pytest.skip()
     cpl = CPLogicProgram()
     cpl.add_probabilistic_facts_from_tuples(
-        Q, [(0.2, 7, 8), (0.6, 8, 9), (0.9, 8, 8)],
+        Q,
+        [(0.2, 7, 8), (0.6, 8, 9), (0.9, 8, 8)],
     )
     cpl.add_probabilistic_choice_from_tuples(
-        P, [(0.4, 8), (0.6, 9)],
+        P,
+        [(0.4, 8), (0.6, 9)],
     )
     cpl.walk(Implication(R(Constant[int](8), x), Conjunction((Q(x, x), P(x)))))
     query = Implication(ans(x, y), R(x, y))
@@ -719,7 +721,8 @@ def test_empty_result_program(solver):
     rule = Implication(R(Constant(2), Constant(3)), Conjunction((Q(x),)))
     cpl = CPLogicProgram()
     cpl.add_probabilistic_facts_from_tuples(
-        Q, [(0.2, 7)],
+        Q,
+        [(0.2, 7)],
     )
     cpl.walk(rule)
     query = Implication(ans(x), R(x, x))
@@ -804,17 +807,20 @@ def test_probsemiring_extended_proj():
                 (0.2, "a", "b"),
                 (0.3, "b", "a"),
                 (0.5, "c", "c"),
-            ]
+            ],
         ),
         ColumnStr("_p_"),
     )
     proj_list = [
-        ExtendedProjectionListMember(str2columnstr_constant("x"),
-                                     str2columnstr_constant("x")),
-        ExtendedProjectionListMember(str2columnstr_constant("y"),
-                                     str2columnstr_constant("y")),
-        ExtendedProjectionListMember(Constant("d"),
-                                     str2columnstr_constant("z")),
+        ExtendedProjectionListMember(
+            str2columnstr_constant("x"), str2columnstr_constant("x")
+        ),
+        ExtendedProjectionListMember(
+            str2columnstr_constant("y"), str2columnstr_constant("y")
+        ),
+        ExtendedProjectionListMember(
+            Constant("d"), str2columnstr_constant("z")
+        ),
     ]
     proj = ExtendedProjection(provset, proj_list)
     solver = ProbSemiringSolver()
@@ -826,7 +832,7 @@ def test_probsemiring_extended_proj():
                 (0.2, "a", "b", "d"),
                 (0.3, "b", "a", "d"),
                 (0.5, "c", "c", "d"),
-            ]
+            ],
         ),
         ColumnStr("_p_"),
     )
@@ -841,15 +847,17 @@ def test_probsemiring_forbidden_extended_proj_missing_nonprov_cols():
                 (0.2, "a", "b"),
                 (0.3, "b", "a"),
                 (0.5, "c", "c"),
-            ]
+            ],
         ),
         ColumnStr("_p_"),
     )
     proj_list = [
-        ExtendedProjectionListMember(str2columnstr_constant("x"),
-                                     str2columnstr_constant("x")),
-        ExtendedProjectionListMember(Constant("d"),
-                                     str2columnstr_constant("z")),
+        ExtendedProjectionListMember(
+            str2columnstr_constant("x"), str2columnstr_constant("x")
+        ),
+        ExtendedProjectionListMember(
+            Constant("d"), str2columnstr_constant("z")
+        ),
     ]
     proj = ExtendedProjection(provset, proj_list)
     solver = ProbSemiringSolver()
@@ -865,17 +873,20 @@ def test_probsemiring_forbidden_extended_proj_on_provcol():
                 (0.2, "a", "b"),
                 (0.3, "b", "a"),
                 (0.5, "c", "c"),
-            ]
+            ],
         ),
         ColumnStr("_p_"),
     )
     proj_list = [
-        ExtendedProjectionListMember(str2columnstr_constant("x"),
-                                     str2columnstr_constant("x")),
-        ExtendedProjectionListMember(str2columnstr_constant("y"),
-                                     str2columnstr_constant("y")),
-        ExtendedProjectionListMember(Constant("d"),
-                                     str2columnstr_constant("_p_")),
+        ExtendedProjectionListMember(
+            str2columnstr_constant("x"), str2columnstr_constant("x")
+        ),
+        ExtendedProjectionListMember(
+            str2columnstr_constant("y"), str2columnstr_constant("y")
+        ),
+        ExtendedProjectionListMember(
+            Constant("d"), str2columnstr_constant("_p_")
+        ),
     ]
     proj = ExtendedProjection(provset, proj_list)
     solver = ProbSemiringSolver()

--- a/neurolang/probabilistic/tests/test_probabilistic_solvers.py
+++ b/neurolang/probabilistic/tests/test_probabilistic_solvers.py
@@ -773,6 +773,29 @@ def test_probchoice_selfjoin_multiple_variables(solver):
     assert testing.eq_prov_relations(result, expected)
 
 
+def test_probchoice_selfjoin_multiple_variables_shared_var(solver):
+    if solver is not dichotomy_theorem_based_solver:
+        pytest.skip()
+    cpl = CPLogicProgram()
+    cpl.add_probabilistic_choice_from_tuples(
+        P,
+        [(0.2, "a", "b"), (0.8, "b", "b")],
+    )
+    cpl.add_probabilistic_facts_from_tuples(
+        Q,
+        [(0.6, "a", "b"), (0.8, "b", "a"), (0.2, "b", "b")],
+    )
+    rule = Implication(R(x, y, z), Conjunction((Q(x, y), P(x, y), P(z, x))))
+    cpl.walk(rule)
+    query = Implication(ans(x, y, z), R(x, y, z))
+    result = solver.solve_succ_query(query, cpl)
+    expected = testing.make_prov_set(
+        [(0.2 * 0.8, "b", "b", "b")],
+        ("_p_", "x", "y", "z"),
+    )
+    assert testing.eq_prov_relations(result, expected)
+
+
 def test_probsemiring_extended_proj():
     provset = ProvenanceAlgebraSet(
         NamedRelationalAlgebraFrozenSet(

--- a/neurolang/probabilistic/tests/test_probabilistic_solvers.py
+++ b/neurolang/probabilistic/tests/test_probabilistic_solvers.py
@@ -40,6 +40,7 @@ H = Symbol("H")
 A = Symbol("A")
 B = Symbol("B")
 C = Symbol("C")
+w = Symbol("w")
 x = Symbol("x")
 y = Symbol("y")
 z = Symbol("z")
@@ -745,6 +746,29 @@ def test_program_with_probchoice_selfjoin(solver):
     result = solver.solve_succ_query(query, cpl)
     expected = testing.make_prov_set(
         [(0.2 * 0.6, "a", "a"), (0.8 * 0.8, "b", "b")], ("_p_", "x", "y")
+    )
+    assert testing.eq_prov_relations(result, expected)
+
+
+def test_probchoice_selfjoin_multiple_variables(solver):
+    if solver is not dichotomy_theorem_based_solver:
+        pytest.skip()
+    cpl = CPLogicProgram()
+    cpl.add_probabilistic_choice_from_tuples(
+        P,
+        [(0.2, "a", "b"), (0.8, "b", "c")],
+    )
+    cpl.add_probabilistic_facts_from_tuples(
+        Q,
+        [(0.6, "a"), (0.8, "b")],
+    )
+    rule = Implication(R(x, y, z, w), Conjunction((Q(x), P(x, y), P(z, w))))
+    cpl.walk(rule)
+    query = Implication(ans(x, y, z, w), R(x, y, z, w))
+    result = solver.solve_succ_query(query, cpl)
+    expected = testing.make_prov_set(
+        [(0.2 * 0.6, "a", "b", "a", "b"), (0.8 * 0.8, "b", "c", "b", "c")],
+        ("_p_", "x", "y", "z", "w"),
     )
     assert testing.eq_prov_relations(result, expected)
 


### PR DESCRIPTION
The current version of the code does not handle probabilistic choice self-joins
correctly. What currently happens is that a rule

    ans(x) :- P(x), P(y)

where `P` is a probabilistic choice predicate symbol, is translated by the
lifted optimisation function to the rule

    ans(x) :- P(x), P(y), y = x

Then, when this rule's hierarchicality is verified, it is not hierarchical.

This PR uses unification in the lifted optimisation to apply the variable
equalities and instead return the rule

    ans(x) :- P(x)

In the case where the unification completely removes one variable from the
antecedent that is not a free variable but a head variable, the equality is
maintained in the conjunctive antecedent to make sure the rule stays valid. If
the rule's consequent contains a variable that does not occur in the
antecedent, it's an invalid rule.

For example, the rule (where `P` is a probabilistic choice predicate)

    ans(x, y) :- P(x), P(y)

becomes

    ans(x, y) :- P(x), P(y), y = x

and then is unified as

    ans(x, y) :- P(x)

which is invalid. But, keeping the variable equality maintains the validity of
the rule.