### PR TITLE
Check for __qualname__ presence in Constant.__repr__

### DIFF
--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -548,7 +548,11 @@ class Constant(Expression):
     def __repr__(self):
         if self.value is ...:
             value_str = '...'
-        elif callable(self.value) and not isinstance(self.value, Expression):
+        elif (
+            callable(self.value)
+            and not isinstance(self.value, Expression)
+            and hasattr(self.value, "__qualname__")
+        ):
             value_str = self.value.__qualname__
         else:
             value_str = repr(self.value)

--- a/neurolang/tests/test_expressions.py
+++ b/neurolang/tests/test_expressions.py
@@ -3,6 +3,7 @@ import operator as op
 from typing import AbstractSet, Callable, Mapping, Sequence, Tuple
 
 import pytest
+import numpy
 
 from .. import expressions, logic
 from ..expression_walker import (
@@ -316,3 +317,8 @@ def test_fresh_symbol_subclass():
 
     assert isinstance(TestSymbol.fresh(), TestSymbol)
     assert isinstance(TestSymbol[int].fresh(), TestSymbol[int])
+
+
+def test_numpy_ufunc_no_qualname_repr():
+    exp = C_(numpy.exp)
+    repr(exp)


### PR DESCRIPTION
Stumbled upon this code assumption of the `__qualname__` attribute being
present for all `Constant` values. Sadly, this is not always implemented in the
API of libraries. For example, NumPy's unfunc do not have a `__qualname__`, as
discussed in https://github.com/numpy/numpy/issues/4952. I noticed that other
parts of the NeuroLang code **do check** for the presence of the `__qualname__`
attribute before accessing it. For example, in the `Expression` class

```python
    @property
    def __type_repr__(self):
        if (
            hasattr(self.type, '__qualname__') and
            not hasattr(self.type, '__args__')
        ):
            return self.type.__qualname__
        else:
            return repr(self.type)
```