### PR TITLE
pin pysdd to github repo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
   nibabel
   nilearn>=0.5.0
   pandas>=0.23.4
-  pysdd
+  pysdd @ git+https://github.com/wannesm/PySDD.git#egg=PySDD
   tatsu
   neurosynth==0.3.7
   matplotlib


### PR DESCRIPTION
Pinning pysdd to github repo solves the [import problem in neurolang_gallery](https://github.com/NeuroLang/neurolang_gallery/issues/2) for pysdd.