### PR TITLE
Prevent some post-probabilistic rule to be considered as probabilistic

### DIFF
--- a/neurolang/probabilistic/stratification.py
+++ b/neurolang/probabilistic/stratification.py
@@ -175,7 +175,7 @@ def _get_rule_idb_type(rule, grpd_symbs, wlq_symbs):
         | grpd_symbs["post_probabilistic"]
     ).issuperset(dep_symbs):
         idb_type = "post_probabilistic"
-    elif not grpd_symbs["probabilistic"].isdisjoint(dep_symbs):
+    elif not (grpd_symbs["probabilistic"] - wlq_symbs).isdisjoint(dep_symbs):
         idb_type = "probabilistic"
     return idb_type
 


### PR DESCRIPTION
Fix an error where a rule depending on a post-probabilistic rule was considered
to be probabilistic, which cannot happen as any rule depending on a
post-probabilistic rule must be deterministic and in the post-probabilistic
stratum.