### PR TITLE
[smallfix] only unify symb-to-symb or symb-to-const equality

### DIFF
--- a/neurolang/datalog/expression_processing.py
+++ b/neurolang/datalog/expression_processing.py
@@ -871,8 +871,7 @@ class UnifyVariableEqualitiesMixin(PatternWalker):
         equality_predicates = set(
             predicate
             for predicate in extract_logic_predicates(expression)
-            if predicate.functor == EQ
-            and any(isinstance(arg, Symbol) for arg in predicate.args)
+            if is_var_equality_to_var_or_const(predicate)
         )
         eq_sets = list()
         for equality_predicate in equality_predicates:

--- a/neurolang/datalog/tests/test_unify_vareqs.py
+++ b/neurolang/datalog/tests/test_unify_vareqs.py
@@ -202,3 +202,22 @@ def test_aggregation():
     program = DatalogWithVariableEqualityUnificationAndAggregation()
     with pytest.raises(ForbiddenExpressionError):
         program.walk(rule)
+
+
+def test_unify_vareq_builtin():
+    some_builtin = Constant[typing.Callable[..., str]](
+        lambda s: s + s,
+        verify_type=False,
+        auto_infer_type=False,
+    )
+    rule = Implication(
+        P(x, y),
+        Conjunction((Q(x), Q(y), EQ(x, y), EQ(y, some_builtin(x)))),
+    )
+    program = DatalogWithVariableEqualityUnification()
+    program.walk(rule)
+    expected = Union(
+        (Implication(P(y, y), Conjunction((Q(y), EQ(y, some_builtin(y))))),)
+    )
+    result = program.intensional_database()[P]
+    assert logic_exp_commutative_equal(result, expected)


### PR DESCRIPTION
this is currently failing for expressions with builtin function applications