### PR TITLE
Various changes to allow for Dask/SQL RAS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
       - install
       - restore_cache:
           keys:
-            - v1-docs-{{ .Branch }}--
+            - v2-docs-{{ .Branch }}--
       - run:
           name: Install Texlive and dvipng
           command: 'sudo apt update && sudo apt install texlive texlive-xetex texlive-fonts-extra texlive-latex-extra texlive-plain-extra dvipng'

--- a/neurolang/datalog/aggregation.py
+++ b/neurolang/datalog/aggregation.py
@@ -217,6 +217,11 @@ class ChaseAggregationMixin:
             ls = locals()
             gs['fun_'] = fun_
             fun = eval(fun_str, gs, ls)
+            if (
+                hasattr(fun_, "__annotations__")
+                and "return" in fun_.__annotations__
+            ):
+                fun.__annotations__["return"] = fun_.__annotations__["return"]
         return aggregation_args, fun
 
     def eliminate_already_computed(self, consequent, instance, substitutions):

--- a/neurolang/datalog/chase/relational_algebra.py
+++ b/neurolang/datalog/chase/relational_algebra.py
@@ -360,7 +360,6 @@ class ChaseNamedRelationalAlgebraMixin:
                     if arg in substitutions.columns
                 )
             )
-            new_tuples = WrappedRelationalAlgebraSet(new_tuples)
         else:
             tuples = [
                 tuple(

--- a/neurolang/datalog/tests/test_aggregation.py
+++ b/neurolang/datalog/tests/test_aggregation.py
@@ -2,6 +2,7 @@ from neurolang.exceptions import ForbiddenUnstratifiedAggregation
 from typing import AbstractSet
 
 import pytest
+import numpy as np
 
 from ...expression_walker import ExpressionBasicEvaluator
 from ...expressions import (Constant, ExpressionBlock, NeuroLangException,
@@ -34,7 +35,7 @@ class Datalog(
     def function_sum2(self, x: AbstractSet, y: AbstractSet) -> Unknown:
         return sum(v + w for v, w in zip(x, y))
 
-    def function_set_create(self, x: AbstractSet) -> Unknown:
+    def function_set_create(self, x: AbstractSet) -> np.object_:
         return frozenset(x)
 
 

--- a/neurolang/datalog/tests/test_instance.py
+++ b/neurolang/datalog/tests/test_instance.py
@@ -35,6 +35,7 @@ def test_frozen_map_instance_contains_facts():
     assert Q in instance
     assert instance[Q].value == elements[Q]
     assert hash(instance) is not None
+    assert not instance.is_empty()
 
 
 def test_map_instance_contains_facts():
@@ -42,14 +43,27 @@ def test_map_instance_contains_facts():
     instance = MapInstance(elements)
     assert Q in instance
     assert instance[Q].value == elements[Q]
+    assert not instance.is_empty()
 
 
 def test_copy():
     elements = {Q: ({(C_(2), ), (C_(3), )})}
     instance = SetInstance(elements)
     instance2 = instance.copy()
-
     assert instance == instance2
+    assert not instance2.is_empty()
+
+
+def test_empty():
+    assert SetInstance({}).is_empty()
+    elements = {Q: ({(C_(2), ), (C_(3), )})}
+    instance = SetInstance(elements)
+    instance2 = instance.copy()
+    instance3 = instance - instance2
+    assert instance3.is_empty()
+
+    instance4 = SetInstance({P: ({(C_(2), ), (C_(3), )})})
+    assert (instance & instance4).is_empty()
 
 
 def test_build_instance_from_instance():

--- a/neurolang/expression_walker.py
+++ b/neurolang/expression_walker.py
@@ -189,8 +189,7 @@ class IdentityWalker(PatternWalker):
 
 
 class ExpressionWalker(PatternWalker):
-    """Walks through an expression and each of its arguments
-    """
+    """Walks through an expression and each of its arguments"""
 
     @add_match(Expression)
     def process_expression(self, expression):
@@ -522,4 +521,12 @@ class FunctionApplicationToPythonLambda(PatternWalker):
         gs = globals()
         ls = locals()
         gs.update(arg_dict)
-        return eval(str_eval, gs, ls), param_sym
+        lambda_f = eval(str_eval, gs, ls)
+        if (
+            hasattr(e.functor.value, "__annotations__")
+            and "return" in e.functor.value.__annotations__
+        ):
+            lambda_f.__annotations__[
+                "return"
+            ] = e.functor.value.__annotations__["return"]
+        return lambda_f, param_sym

--- a/neurolang/expression_walker.py
+++ b/neurolang/expression_walker.py
@@ -522,11 +522,10 @@ class FunctionApplicationToPythonLambda(PatternWalker):
         ls = locals()
         gs.update(arg_dict)
         lambda_f = eval(str_eval, gs, ls)
-        if (
-            hasattr(e.functor.value, "__annotations__")
-            and "return" in e.functor.value.__annotations__
-        ):
-            lambda_f.__annotations__[
-                "return"
-            ] = e.functor.value.__annotations__["return"]
+        if hasattr(e.functor.value, "__annotations__"):
+            for p in param_sym | {"return"}:
+                if p in e.functor.value.__annotations__:
+                    lambda_f.__annotations__[
+                        p
+                    ] = e.functor.value.__annotations__[p]
         return lambda_f, param_sym

--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -442,7 +442,7 @@ class Symbol(NonConstant):
         return 'S{{{}: {}}}'.format(self.name, self.__type_repr__)
 
     def __getstate__(self):
-        # Pickle a tuple instead of a set for _symbols to avoid calling hash 
+        # Pickle a tuple instead of a set for _symbols to avoid calling hash
         # upon deserialization
         state = self.__dict__.copy()
         state["_symbols"] = tuple(self._symbols)

--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from functools import WRAPPER_ASSIGNMENTS, lru_cache, wraps
 from itertools import chain
 from warnings import warn
+import warnings
 
 from .exceptions import NeuroLangException
 from .type_system import NeuroLangTypeException, Unknown
@@ -385,6 +386,12 @@ class Expression(metaclass=ExpressionMeta):
         int
             Always -1
         """
+        warnings.warn(
+            "You are comparing together Expressions. "
+            "Comparison of Expressions is not implemented properly and you"
+            " should not expect it to work.",
+            SyntaxWarning,
+        )
         return -1
 
 

--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -373,6 +373,20 @@ class Expression(metaclass=ExpressionMeta):
     def __hash__(self):
         return hash(tuple(getattr(self, c) for c in self.__children__))
 
+    def __lt__(self, other):
+        """
+        You shouldn't have to compare Expressions, but need it when
+        using Dask RAS because we use the "first" aggregate function to get
+        a single value for each grouped_by column and this function uses
+        sort (on only one value, but still).
+
+        Returns
+        -------
+        int
+            Always -1
+        """
+        return -1
+
 
 class ExpressionBlock(Expression):
     def __init__(self, expressions):
@@ -419,6 +433,18 @@ class Symbol(NonConstant):
 
     def __repr__(self):
         return 'S{{{}: {}}}'.format(self.name, self.__type_repr__)
+
+    def __getstate__(self):
+        # Pickle a tuple instead of a set for _symbols to avoid calling hash 
+        # upon deserialization
+        state = self.__dict__.copy()
+        state["_symbols"] = tuple(self._symbols)
+        return state
+
+    def __setstate__(self, state: dict):
+        symbols = state.pop("_symbols")
+        self.__dict__ = state
+        self._symbols = set(symbols)
 
     @staticmethod
     def _fresh_generator():
@@ -565,6 +591,13 @@ class Constant(Expression):
                 "The value %s does not correspond to the type %s" %
                 (self.value, self.type)
             )
+
+    def __reduce__(self):
+        """
+        Make Constants pickable.
+        See https://docs.python.org/3/library/pickle.html#object.__reduce__
+        """
+        return (Constant, (self.value, ))
 
 
 class Lambda(Definition):

--- a/neurolang/neurolang.py
+++ b/neurolang/neurolang.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from .utils import config
 from neurolang.frontend import (
     ExplicitVBR,
     ExplicitVBROverlay,
@@ -29,4 +30,5 @@ __all__ = [
     "ExplicitVBR",
     "ExplicitVBROverlay",
     "exceptions",
+    "config",
 ]

--- a/neurolang/probabilistic/weighted_model_counting.py
+++ b/neurolang/probabilistic/weighted_model_counting.py
@@ -169,8 +169,9 @@ class WMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
             tags = [Symbol.fresh() for _ in range(len(df))]
             probs = [1.0 for _ in range(len(df))]
             tag_set = list(zip(tags, probs))
+            prob_column = Symbol.fresh().name
             return self._build_tag_and_prov_sets(
-                relation, relation_symbol, df, -1, tag_set, tags
+                relation, relation_symbol, df, prob_column, tag_set, tags
             )
 
     @add_match(ProbabilisticFactSet(Symbol, Constant))
@@ -233,8 +234,7 @@ class WMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
         self.tagged_sets.append(tag_set)
         tagged_df = df.copy()
         new_columns = tuple(f"col_{c}" for c in relation.value.columns)
-        if prob_column == -1:
-            prob_column = Symbol.fresh().name
+        if prob_column not in relation.value.columns:
             new_columns = new_columns + (f"col_{prob_column}",)
         tagged_df[prob_column] = prov_column
         tagged_ras_set = NamedRelationalAlgebraFrozenSet(

--- a/neurolang/probabilistic/weighted_model_counting.py
+++ b/neurolang/probabilistic/weighted_model_counting.py
@@ -250,7 +250,7 @@ class WMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
         self.tagged_sets.append(tag_set)
         tagged_df = df.copy()
         new_columns = tuple(f"col_{c}" for c in relation.value.columns)
-        if prob_column not in relation.value.columns:
+        if prob_column not in df.columns:
             new_columns = new_columns + (f"col_{prob_column}",)
         tagged_df[prob_column] = prov_column
         tagged_ras_set = NamedRelationalAlgebraFrozenSet(

--- a/neurolang/probabilistic/weighted_model_counting.py
+++ b/neurolang/probabilistic/weighted_model_counting.py
@@ -21,6 +21,7 @@ from ..expressions import (
     ExpressionBlock,
     FunctionApplication,
     Symbol,
+    sure_is_not_pattern,
 )
 from ..logic import Conjunction, Implication
 from ..logic.expression_processing import (
@@ -209,12 +210,13 @@ class WMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
             previous_probability = 0
             prov_column = []
             tag_set = []
-            for probability in df[prob_column]:
-                adjusted_probability = probability / (1 - previous_probability)
-                previous_probability += probability
-                previous = self._generate_tag_choice_expression(
-                    previous, adjusted_probability, prov_column, tag_set
-                )
+            with sure_is_not_pattern():
+                for probability in df[prob_column]:
+                    adjusted_probability = probability / (1 - previous_probability)
+                    previous_probability += probability
+                    previous = self._generate_tag_choice_expression(
+                        previous, adjusted_probability, prov_column, tag_set
+                    )
 
             return self._build_tag_and_prov_sets(
                 relation,

--- a/neurolang/relational_algebra_provenance.py
+++ b/neurolang/relational_algebra_provenance.py
@@ -604,7 +604,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
         args = tuple(x)
         if len(args) == 1:
             r = args[0]
-        if isinstance(args[0], Expression):
+        elif isinstance(args[0], Expression):
             r = FunctionApplication(
                 ADD, args, validate_arguments=False, verify_type=False
             )

--- a/neurolang/tests/test_expressions.py
+++ b/neurolang/tests/test_expressions.py
@@ -2,6 +2,7 @@ import inspect
 import operator as op
 from typing import AbstractSet, Callable, Mapping, Sequence, Tuple
 
+import pickle
 import pytest
 import numpy
 
@@ -47,6 +48,19 @@ def test_build_constants():
     assert len(b.value) == 1
     assert C_('a') in b.value
     assert C_(1) in b.value.values()
+
+
+def test_pickle_constants():
+    a = C_('ab')
+    assert pickle.loads(pickle.dumps(a)) == a
+    b = C_(['a'])
+    assert pickle.loads(pickle.dumps(b)) == b
+    c = C_(('a', 1))
+    assert pickle.loads(pickle.dumps(c)) == c
+    d = C_({'a'})
+    assert pickle.loads(pickle.dumps(d)) == d
+    e = C_({'a': 1})
+    assert pickle.loads(pickle.dumps(e)) == e
 
 
 def test_fresh_symbol():

--- a/neurolang/utils/__init__.py
+++ b/neurolang/utils/__init__.py
@@ -1,4 +1,6 @@
+from .config import config
 from .orderedset import OrderedSet
+
 from .relational_algebra_set import (
     NamedRelationalAlgebraFrozenSet,
     RelationalAlgebraFrozenSet,
@@ -9,5 +11,5 @@ from .various import log_performance
 __all__ = [
     'OrderedSet', 'RelationalAlgebraSet',
     'RelationalAlgebraFrozenSet', 'NamedRelationalAlgebraFrozenSet',
-    'log_performance'
+    'log_performance', 'config'
 ]

--- a/neurolang/utils/config/__init__.py
+++ b/neurolang/utils/config/__init__.py
@@ -1,17 +1,17 @@
-"""Configuration module for Relational Algebra Sets.
-# TODO : Maybe move this to a root dir for Neurolang ?
-"""
 import configparser
 import logging
 import os
+import sys
 
 LOG = logging.getLogger(__name__)
 
 config = configparser.ConfigParser()
-config_file = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "config.ini"
-)
-LOG.info(f"Reading configuration file for Neurolang: {config_file}")
-config.read(config_file)
-LOG.info(f"Read config file with sections {config.sections()}")
 
+config_dirs = [os.path.join(sys.prefix, 'config'), os.path.dirname(os.path.realpath(__file__))]
+for d in config_dirs:
+    config_file = os.path.join(d, "config.ini")
+    if os.path.isfile(config_file):
+        LOG.info(f"Reading configuration file for Neurolang: {config_file}")
+        config.read(config_file)
+        LOG.info(f"Read config file with sections {config.sections()}")
+        break

--- a/neurolang/utils/config/__init__.py
+++ b/neurolang/utils/config/__init__.py
@@ -1,0 +1,17 @@
+"""Configuration module for Relational Algebra Sets.
+# TODO : Maybe move this to a root dir for Neurolang ?
+"""
+import configparser
+import logging
+import os
+
+LOG = logging.getLogger(__name__)
+
+config = configparser.ConfigParser()
+config_file = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "config.ini"
+)
+LOG.info(f"Reading configuration file for Neurolang: {config_file}")
+config.read(config_file)
+LOG.info(f"Read config file with sections {config.sections()}")
+

--- a/neurolang/utils/config/config.ini
+++ b/neurolang/utils/config/config.ini
@@ -1,0 +1,10 @@
+[DEFAULT]
+debug = False
+
+[RAS]
+# Which backend to use for RAS: pandas, dask or sql
+Backend = pandas
+# When running dask backend, use synchronous or asynchronous scheduler
+Synchronous = True
+# Use uuid or human readable ids for tables and views when using dask backend
+TableIds = human

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
   nibabel
   nilearn>=0.5.0
   pandas>=0.23.4,<1.2.0
+  pysdd @ git+https://github.com/wannesm/PySDD.git#egg=PySDD
   tatsu
   neurosynth==0.3.7
   scikit-learn<0.24

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
   nibabel
   nilearn>=0.5.0
   pandas>=0.23.4,<1.2.0
-  pysdd @ git+https://github.com/wannesm/PySDD.git#egg=PySDD
   tatsu
   neurosynth==0.3.7
   scikit-learn<0.24
@@ -62,6 +61,8 @@ doc =
   sphinx-gallery
   numpydoc
 
+[options.data_files]
+config = neurolang/utils/config/config.ini
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Various changes and refactoring to prepare Neurolang for Dask/SQL relational algebra sets (#619), including :

* optimisation of instances to avoid inplace unions (better/easier to work with immutable sets) and checking whether an instance's elements are empty as much as possible
* make Symbols and Constants pickable, so that they can be added to Dask RAS
* add type annotations to lambda functions for better type inference
* add a config file for neurolang. I put it in neurolang.utils for now, but it should probably be moved someplace else (maybe move it after merge ?)
* Refactoring of the WMCSemiringSolver so that it can be used instead of the SddSemiringSolver which doesn't work with dask
