### PR TITLE
Add query and exists implementation to datalog parser

### DIFF
--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -3,7 +3,7 @@ from operator import add, eq, mul, pow, sub, truediv
 
 from ....datalog import Conjunction, Fact, Implication, Negation, Union
 from ....probabilistic.expressions import Condition, ProbabilisticPredicate
-from ....expressions import Constant, Symbol, FunctionApplication
+from ....expressions import Constant, Query, Symbol, FunctionApplication
 from ..standard_syntax import ExternalSymbol, parser
 
 
@@ -282,3 +282,14 @@ def test_existential():
     )
 
     assert res == expected
+
+def test_query():
+    ans = Symbol("ans")
+    B = Symbol("B")
+    C = Symbol("C")
+    x = Symbol("x")
+    y = Symbol("y")
+    res = parser("ans(x) :- B(x, y), C(3, y)")
+    assert res == Union(
+        (Query(ans(x), Conjunction((B(x, y), C(Constant(3), y)))),)
+    )

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -240,32 +240,45 @@ def test_condition():
 
 
 def test_existential():
-    A = Symbol('A')
-    B = Symbol('B')
-    C = Symbol('C')
-    x = Symbol('x')
-    s1 = Symbol('s1')
-    s2 = Symbol('s2')
+    A = Symbol("A")
+    B = Symbol("B")
+    C = Symbol("C")
+    x = Symbol("x")
+    s1 = Symbol("s1")
+    s2 = Symbol("s2")
 
-    res = parser('C(x) :- B(x), exists(s1; A(s1))')
-    expected = Union((
-        Implication(
-            C(x),
-            Conjunction((B(x), ExistentialPredicate(s1, A(s1))))
-        ),
-    ))
-    assert res == expected
-    
-    res = parser('C(x) :- B(x), ∃(s1 st A(s1))')
+    res = parser("C(x) :- B(x), exists(s1; A(s1))")
+    expected = Union(
+        (
+            Implication(
+                C(x), Conjunction((B(x), ExistentialPredicate(s1, A(s1))))
+            ),
+        )
+    )
     assert res == expected
 
-    res = parser('C(x) :- B(x), exists(s1, s2; (A(s1), A(s2)))')
+    res = parser("C(x) :- B(x), ∃(s1 st A(s1))")
+    assert res == expected
 
-    expected = Union((
-        Implication(
-            C(x),
-            Conjunction((B(x), ExistentialPredicate(s2, ExistentialPredicate(s1, Conjunction((A(s1), A(s2))))), ))
-        ),
-    ))
+    res = parser("C(x) :- B(x), exists(s1, s2; (A(s1), A(s2)))")
+
+    expected = Union(
+        (
+            Implication(
+                C(x),
+                Conjunction(
+                    (
+                        B(x),
+                        ExistentialPredicate(
+                            s2,
+                            ExistentialPredicate(
+                                s1, Conjunction((A(s1), A(s2)))
+                            ),
+                        ),
+                    )
+                ),
+            ),
+        )
+    )
 
     assert res == expected

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -1,3 +1,4 @@
+from neurolang.logic import ExistentialPredicate
 from operator import add, eq, mul, pow, sub, truediv
 
 from ....datalog import Conjunction, Fact, Implication, Negation, Union
@@ -232,6 +233,38 @@ def test_condition():
         Implication(
             C(x),
             Condition(A(x), Conjunction((A(x), B(x))))
+        ),
+    ))
+
+    assert res == expected
+
+
+def test_existential():
+    A = Symbol('A')
+    B = Symbol('B')
+    C = Symbol('C')
+    x = Symbol('x')
+    s1 = Symbol('s1')
+    s2 = Symbol('s2')
+
+    res = parser('C(x) :- B(x), exists(s1; A(s1))')
+    expected = Union((
+        Implication(
+            C(x),
+            Conjunction((B(x), ExistentialPredicate(s1, A(s1))))
+        ),
+    ))
+    assert res == expected
+    
+    res = parser('C(x) :- B(x), ∃(s1 st A(s1))')
+    assert res == expected
+
+    res = parser('C(x) :- B(x), exists(s1, s2; (A(s1), A(s2)))')
+
+    expected = Union((
+        Implication(
+            C(x),
+            Conjunction((B(x), ExistentialPredicate(s2, ExistentialPredicate(s1, Conjunction((A(s1), A(s2))))), ))
         ),
     ))
 


### PR DESCRIPTION
Extend datalog parser implementation to support exists predicates and query rules.