### PR TITLE
Pass row_type from IR solution to frontend solution set when solving a query

### DIFF
--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -74,6 +74,11 @@ from .datalog.sugar import (
 from .datalog.sugar.spatial import TranslateEuclideanDistanceBoundMatrixMixin
 from .datalog.syntax_preprocessing import ProbFol2DatalogMixin
 from .query_resolution_datalog import QueryBuilderDatalog
+from neurolang.type_system import (
+    get_args,
+    get_origin,
+    replace_type_variable_fix_python36_37,
+)
 
 
 class RegionFrontendCPLogicSolver(
@@ -445,6 +450,7 @@ class NeurolangPDL(QueryBuilderDatalog):
                 NamedRelationalAlgebraFrozenSet.dum()
             )
         query_solution = solution[pred_symb].value.unwrap()
+        query_row_type = solution[pred_symb].value.row_type
         cols = list(
             arg.name
             for arg in predicate.expression.args
@@ -453,6 +459,14 @@ class NeurolangPDL(QueryBuilderDatalog):
         query_solution = NamedRelationalAlgebraFrozenSet(cols, query_solution)
         query_solution = query_solution.projection(
             *(symb.name for symb in head_symbols)
+        )
+        type_args = get_args(query_row_type)
+        proj_row_type = tuple(
+            type_args[cols.index(symb.name)] for symb in head_symbols
+        )
+        origin = get_origin(query_row_type)
+        query_solution.row_type = replace_type_variable_fix_python36_37(
+            query_row_type, origin, proj_row_type
         )
         return ir.Constant[AbstractSet](query_solution)
 

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -428,10 +428,12 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         self.program_ir.symbol_table = self.symbol_table.enclosing_scope
 
         if isinstance(head, tuple):
+            row_type = solution_set.value.row_type
             solution_set = NamedRelationalAlgebraFrozenSet(
                     tuple(s.expression.name for s in head),
                     solution_set.value.unwrap()
                 )
+            solution_set.row_type = row_type
         return solution_set, functor_orig
 
     def solve_all(self) -> Dict[str, NamedRelationalAlgebraFrozenSet]:

--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -328,8 +328,9 @@ def test_neurolang_dl_query():
 
     dataset = {(i, i * 2) for i in range(10)}
     q = neurolang.add_tuple_set(dataset, name="q")
-    sol = neurolang.query((x, y), q(x, y)).to_unnamed()
-    assert sol == dataset
+    sol = neurolang.query((x, y), q(x, y))
+    assert sol.to_unnamed() == dataset
+    assert sol.row_type == Tuple[int, int]
 
     sol = neurolang.query(tuple(), q(x, x))
     assert sol
@@ -486,6 +487,7 @@ def test_neurolang_dl_datalog_code_with_query():
         prog + "\nans(x) :- B(x, y), y == 5"
     )
     assert res.to_unnamed() == {(4,), (5,), (6,)}
+    assert res.row_type == Tuple[int, ]
 
     res = neurolang.execute_datalog_program(prog + "\nans() :- B(x, y)")
     assert res == True

--- a/neurolang/frontend/tests/test_probabilistic_frontend.py
+++ b/neurolang/frontend/tests/test_probabilistic_frontend.py
@@ -265,7 +265,9 @@ def test_solve_query():
         ]
     )
     assert_almost_equal(res, expected)
+    assert res.row_type == Tuple[str, float]
     assert_almost_equal(res_2, expected.projection(1))
+    assert res_2.row_type == Tuple[float]
 
 
 def test_solve_query_prob_col_not_last():


### PR DESCRIPTION
We need row_type for the result sets in order to display results properly in the frontend. 
This is already done in `QueryBuilderDatalog.solve_all` but not in `QueryBuilderDatalog.query`. 
This PR passes the row_type for the solution when solving a query.