### PR TITLE
Allow arithmetic operations in probabilistic facts

### DIFF
--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -20,7 +20,7 @@ GRAMMAR = u"""
     expressions = ( newline ).{ probabilistic_expression | expression };
 
 
-    probabilistic_expression = (float | int_ext_identifier ) '::' expression ;
+    probabilistic_expression = ( arithmetic_operation | int_ext_identifier ) '::' expression ;
     expression = rule | constraint | fact;
     fact = constant_predicate ;
     rule = (head | query) implication (condition | body) ;

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -1,5 +1,5 @@
 from neurolang.logic import ExistentialPredicate
-from operator import add, eq, mul, pow, sub, truediv
+from operator import add, eq, lt, mul, pow, sub, truediv
 
 from ....datalog import Conjunction, Fact, Implication, Negation, Union
 from ....probabilistic.expressions import Condition, ProbabilisticPredicate
@@ -198,6 +198,31 @@ def test_probabilistic_fact():
             Constant(True)
         ),
     ))
+
+    exp = Symbol("exp")
+    d = Symbol("d")
+    x = Symbol("x")
+    B = Symbol("B")
+    res = parser("exp((-1 * d) / 5.0) :: B(x) :- A(x, d) & (d < 0.8)")
+    expected = Union(
+        (
+            Implication(
+                ProbabilisticPredicate(
+                    FunctionApplication(
+                        exp,
+                        (
+                            Constant(truediv)(
+                                Constant(mul)(Constant(-1), d), Constant(5.0)
+                            ),
+                        ),
+                    ),
+                    B(x),
+                ),
+                Conjunction((A(x, d), Constant(lt)(d, Constant(0.8)))),
+            ),
+        )
+    )
+    assert res == expected
 
 
 def test_condition():


### PR DESCRIPTION
Extend the datalog standard syntax parser to allow arithmetic operations in probabilistic predicates.
This is required for example when using smoothing for the spatial prior where the probability for a voxel to be reported is defined by an arithmetic operation on the distance to the seed voxel, i.e.

```
exp(-d / 5.0) :: VoxelReported (x, y, z, s) :- PeakReported(x2, y2, z2, s) & Voxel(x, y, z) & (d == EUCLIDEAN(x, y, z, x2, y2, z2)) & (d < 1)
```