### PR TITLE
Implement intermediary representation of aggregate operation to refactor provenance algebra projection.

### DIFF
--- a/neurolang/datalog/tests/test_cq_disj_to_named_ra.py
+++ b/neurolang/datalog/tests/test_cq_disj_to_named_ra.py
@@ -13,7 +13,7 @@ from ...relational_algebra import (
     Destroy,
     Difference,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     NameColumns,
     NaturalJoin,
     Projection,
@@ -122,13 +122,13 @@ def test_equality_symbols():
     expected_result = ExtendedProjection(
         fb_trans,
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnStr("x")), Constant(ColumnStr("x"))
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnStr("y")), Constant(ColumnStr("y"))
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnStr("x")), Constant(ColumnStr("z"))
             ),
         ),
@@ -142,13 +142,13 @@ def test_equality_symbols():
     expected_result = ExtendedProjection(
         fb_trans,
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnStr("x")), Constant(ColumnStr("x"))
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnStr("y")), Constant(ColumnStr("y"))
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnStr("x")), Constant(ColumnStr("z"))
             ),
         ),
@@ -249,9 +249,9 @@ def test_extended_projection():
     exp_trans = ExtendedProjection(
         fa_trans,
         [
-            ExtendedProjectionListMember(*builtin_condition.args),
-            ExtendedProjectionListMember(x, x),
-            ExtendedProjectionListMember(y, y),
+            FunctionApplicationListMember(*builtin_condition.args),
+            FunctionApplicationListMember(x, x),
+            FunctionApplicationListMember(y, y),
         ],
     )
     assert res == exp_trans
@@ -292,12 +292,12 @@ def test_extended_projection_2():
     exp_trans = ExtendedProjection(
         fa_trans,
         [
-            ExtendedProjectionListMember(*builtin_condition_1.args),
-            ExtendedProjectionListMember(*builtin_condition_2.args),
-            ExtendedProjectionListMember(x, x),
-            ExtendedProjectionListMember(y, y),
-            ExtendedProjectionListMember(u, u),
-            ExtendedProjectionListMember(v, v),
+            FunctionApplicationListMember(*builtin_condition_1.args),
+            FunctionApplicationListMember(*builtin_condition_2.args),
+            FunctionApplicationListMember(x, x),
+            FunctionApplicationListMember(y, y),
+            FunctionApplicationListMember(u, u),
+            FunctionApplicationListMember(v, v),
         ],
     )
     assert res == exp_trans
@@ -443,20 +443,20 @@ def test_border_cases():
         ExtendedProjection(
             NameColumns(Projection(R1, (C_(0),)), (C_("x"),)),
             (
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     C_(ColumnStr("x")),
                     C_(ColumnStr("x")),
                 ),
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     C_(ColumnStr("x")),
                     C_(ColumnStr("y")),
                 ),
             ),
         ),
         (
-            ExtendedProjectionListMember(C_("x"), C_("x")),
-            ExtendedProjectionListMember(C_("y"), C_("y")),
-            ExtendedProjectionListMember(C_(2) * C_("y"), C_("z")),
+            FunctionApplicationListMember(C_("x"), C_("x")),
+            FunctionApplicationListMember(C_("y"), C_("y")),
+            FunctionApplicationListMember(C_(2) * C_("y"), C_("z")),
         ),
     )
     assert res == expected_res
@@ -515,11 +515,11 @@ def test_extended_projection_variable_equality():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("y"),
             ),
@@ -540,11 +540,11 @@ def test_extended_projection_variable_equality_constant():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant("a"),
                 str2columnstr_constant("y"),
             ),
@@ -565,15 +565,15 @@ def test_extended_projection_variable_equality_not_named():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("y"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("y"),
                 str2columnstr_constant("z"),
             ),
@@ -595,15 +595,15 @@ def test_extended_projection_variable_equality_twice_same_lhs():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("y"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("z"),
             ),
@@ -624,15 +624,15 @@ def test_double_equality():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("z"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("y"),
             ),
@@ -655,19 +655,19 @@ def test_three_way_equality():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("w"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("w"),
                 str2columnstr_constant("y"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("y"),
                 str2columnstr_constant("z"),
             ),
@@ -691,23 +691,23 @@ def test_not_ordered_equalites():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("h"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("h"),
                 str2columnstr_constant("w"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("w"),
                 str2columnstr_constant("y"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("y"),
                 str2columnstr_constant("z"),
             ),
@@ -736,15 +736,15 @@ def test_equality_builtin_application():
             ),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("y"),
                 str2columnstr_constant("y"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 f(C_(ColumnStr("x")), C_(ColumnStr("y"))),
                 str2columnstr_constant("z"),
             ),
@@ -774,15 +774,15 @@ def test_equality_nested_builtin_application():
             ),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("y"),
                 str2columnstr_constant("y"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 f(g(C_(ColumnStr("x"))), g(C_(ColumnStr("y")))),
                 str2columnstr_constant("z"),
             ),
@@ -805,11 +805,11 @@ def test_arithmetic_extended_projection():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(1)
                 / (Constant(1) + (Constant(3) * C_(ColumnStr("x")))),
                 str2columnstr_constant("z"),
@@ -834,11 +834,11 @@ def test_extended_projection_constant_callable():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 EXP(Constant(ColumnStr("x"))),
                 str2columnstr_constant("z"),
             ),
@@ -864,11 +864,11 @@ def test_sigmoid():
             (C_(ColumnStr("x")),),
         ),
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(1) / (Constant(1) + EXP(-C_(ColumnStr("x")))),
                 str2columnstr_constant("z"),
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant("x"),
                 str2columnstr_constant("x"),
             ),

--- a/neurolang/datalog/translate_to_named_ra.py
+++ b/neurolang/datalog/translate_to_named_ra.py
@@ -21,7 +21,7 @@ from ..relational_algebra import (
     Destroy,
     Difference,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     NameColumns,
     NaturalJoin,
     Projection,
@@ -425,7 +425,7 @@ class TranslateToNamedRA(ExpressionBasicEvaluator):
     ):
         named_columns = classified_formulas["named_columns"]
         extended_projections = tuple(
-            ExtendedProjectionListMember(c, c) for c in named_columns
+            FunctionApplicationListMember(c, c) for c in named_columns
         )
         stack = list(classified_formulas["eq_formulas"])
         if len(stack) == 0:
@@ -451,7 +451,7 @@ class TranslateToNamedRA(ExpressionBasicEvaluator):
             else:
                 stack.insert(0, formula)
                 continue
-            extended_projections += (ExtendedProjectionListMember(src, dst),)
+            extended_projections += (FunctionApplicationListMember(src, dst),)
             named_columns.add(dst)
             seen_counts = collections.defaultdict(int)
         new_output = ExtendedProjection(output, extended_projections)
@@ -478,7 +478,7 @@ class TranslateToNamedRA(ExpressionBasicEvaluator):
             cols_for_fun_exp = get_expression_columns(fun_exp)
             if cols_for_fun_exp.issubset(named_columns):
                 extended_projections.append(
-                    ExtendedProjectionListMember(fun_exp, dst_column)
+                    FunctionApplicationListMember(fun_exp, dst_column)
                 )
                 dst_columns.add(dst_column)
             else:
@@ -486,7 +486,7 @@ class TranslateToNamedRA(ExpressionBasicEvaluator):
         if len(extended_projections) > 0:
             for column in classified_formulas["named_columns"]:
                 extended_projections.append(
-                    ExtendedProjectionListMember(column, column)
+                    FunctionApplicationListMember(column, column)
                 )
             output = ExtendedProjection(output, extended_projections)
 

--- a/neurolang/probabilistic/dichotomy_theorem_based_solver.py
+++ b/neurolang/probabilistic/dichotomy_theorem_based_solver.py
@@ -40,7 +40,7 @@ from ..relational_algebra import (
     ColumnStr,
     EliminateTrivialProjections,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     NameColumns,
     NamedRelationalAlgebraFrozenSet,
     Projection,
@@ -147,7 +147,7 @@ class ProbSemiringSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
             str2columnstr_constant(f"col_{i}") for i in relation.value.columns
         )
         projection_list = [
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant[RelationalAlgebraStringExpression](
                     RelationalAlgebraStringExpression(c.value),
                     verify_type=False,
@@ -163,7 +163,7 @@ class ProbSemiringSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
                 NameColumns(relation, named_columns),
                 tuple(projection_list)
                 + (
-                    ExtendedProjectionListMember(
+                    FunctionApplicationListMember(
                         Constant[float](1.0),
                         str2columnstr_constant(prov_column),
                     ),
@@ -219,7 +219,7 @@ class ProbSemiringSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
         prov_col = str2columnstr_constant(provset.provenance_column)
         new_prov_col = str2columnstr_constant(Symbol.fresh().name)
         proj_list_with_prov_col = proj_op.projection_list + (
-            ExtendedProjectionListMember(prov_col, new_prov_col),
+            FunctionApplicationListMember(prov_col, new_prov_col),
         )
         ra_op = ExtendedProjection(relation, proj_list_with_prov_col)
         new_relation = self.walk(ra_op)
@@ -373,7 +373,7 @@ def _maybe_reintroduce_head_variables(ra_query, flat_query, unified_query):
                     f"Unexpected argument {new}. "
                     "Expected symbol or constant"
                 )
-        member = ExtendedProjectionListMember(fun_exp, dst_column)
+        member = FunctionApplicationListMember(fun_exp, dst_column)
         proj_list.append(member)
     return ExtendedProjection(ra_query, tuple(proj_list))
 

--- a/neurolang/probabilistic/tests/test_probabilistic_solvers.py
+++ b/neurolang/probabilistic/tests/test_probabilistic_solvers.py
@@ -9,7 +9,7 @@ from ...logic import Conjunction, Implication, Union
 from ...relational_algebra import (
     ColumnStr,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     NamedRelationalAlgebraFrozenSet,
     RenameColumn,
     str2columnstr_constant,
@@ -812,13 +812,13 @@ def test_probsemiring_extended_proj():
         ColumnStr("_p_"),
     )
     proj_list = [
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             str2columnstr_constant("x"), str2columnstr_constant("x")
         ),
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             str2columnstr_constant("y"), str2columnstr_constant("y")
         ),
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             Constant("d"), str2columnstr_constant("z")
         ),
     ]
@@ -852,10 +852,10 @@ def test_probsemiring_forbidden_extended_proj_missing_nonprov_cols():
         ColumnStr("_p_"),
     )
     proj_list = [
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             str2columnstr_constant("x"), str2columnstr_constant("x")
         ),
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             Constant("d"), str2columnstr_constant("z")
         ),
     ]
@@ -878,13 +878,13 @@ def test_probsemiring_forbidden_extended_proj_on_provcol():
         ColumnStr("_p_"),
     )
     proj_list = [
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             str2columnstr_constant("x"), str2columnstr_constant("x")
         ),
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             str2columnstr_constant("y"), str2columnstr_constant("y")
         ),
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             Constant("d"), str2columnstr_constant("_p_")
         ),
     ]

--- a/neurolang/probabilistic/weighted_model_counting.py
+++ b/neurolang/probabilistic/weighted_model_counting.py
@@ -335,7 +335,15 @@ class SDDWMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
         self.positive_weights.append(probability)
         return literal
 
-    def _semiring_agg_sum(self, x):
+    def _semiring_agg_sum(self, args):
+        return FunctionApplication(
+            Constant(self._internal_sum),
+            args,
+            validate_arguments=False,
+            verify_type=False,
+        )
+
+    def _internal_sum(self, x):
         sum_ = self.manager.false()
         for el in x:
             el.ref()

--- a/neurolang/probabilistic/weighted_model_counting.py
+++ b/neurolang/probabilistic/weighted_model_counting.py
@@ -34,7 +34,7 @@ from ..logic.expression_processing import (
 from ..relational_algebra import (
     ColumnStr,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     NameColumns,
     Projection,
     RelationalAlgebraPushInSelections,
@@ -404,7 +404,7 @@ class SDDWMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
 
         rap_column = str2columnstr_constant(Symbol.fresh().name)
         projection_list = [
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant[RelationalAlgebraStringExpression](
                     RelationalAlgebraStringExpression(c.value),
                     verify_type=False
@@ -422,7 +422,7 @@ class SDDWMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
             ExtendedProjection(
                 relation,
                 projection_list + [
-                    ExtendedProjectionListMember(
+                    FunctionApplicationListMember(
                         deterministic_tag_function,
                         rap_column
                     )
@@ -463,7 +463,7 @@ class SDDWMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
 
             rap_column = str2columnstr_constant(Symbol.fresh().name)
             projection_list = [
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     Constant[RelationalAlgebraStringExpression](
                         RelationalAlgebraStringExpression(c.value),
                         verify_type=False
@@ -481,7 +481,7 @@ class SDDWMCSemiRingSolver(RelationalAlgebraProvenanceExpressionSemringSolver):
                 ExtendedProjection(
                     relation,
                     projection_list + [
-                        ExtendedProjectionListMember(
+                        FunctionApplicationListMember(
                             probfact_tag_function,
                             rap_column
                         )

--- a/neurolang/relational_algebra.py
+++ b/neurolang/relational_algebra.py
@@ -244,8 +244,8 @@ class GroupByAggregation(RelationalAlgebraOperation):
     ----------
     relation : Expression[AbstractSet]
         Relation on which the groupby is applied.
-    groupby : List[`Constant[ColumnStr]` or `Symbol[ColumnStr]`]
-        The list of columns on which to group
+    groupby : `List[Union[Constant[ColumnStr], Symbol[ColumnStr]]]`
+        The list of columns on which to group.
     aggregate_functions : Tuple[FunctionApplicationListMember]
         List of aggregate functions to apply.
 
@@ -321,7 +321,7 @@ class FunctionApplicationListMember(Definition):
     Representation of a function application to a column. Can be used to
     represent either the application of an extended projection, or the
     application of an aggregate function, to a column.
-    
+
 
     Attributes
     ----------

--- a/neurolang/relational_algebra.py
+++ b/neurolang/relational_algebra.py
@@ -244,7 +244,7 @@ class GroupByAggregation(RelationalAlgebraOperation):
     ----------
     relation : Expression[AbstractSet]
         Relation on which the groupby is applied.
-    groupby : `List[Union[Constant[ColumnStr], Symbol[ColumnStr]]]`
+    groupby : `Tuple[Union[Constant[ColumnStr], Symbol[ColumnStr]]]`
         The list of columns on which to group.
     aggregate_functions : Tuple[FunctionApplicationListMember]
         List of aggregate functions to apply.
@@ -806,11 +806,9 @@ class RelationalAlgebraSolver(ew.ExpressionWalker):
         groupby = (c.value for c in agg_op.groupby)
         aggregate_functions = []
         for member in agg_op.aggregate_functions:
-            fun_args = (
-                member.fun_exp.args
-                if len(member.fun_exp.args) > 1
-                else member.fun_exp.args[0]
-            )
+            fun_args = [arg.value for arg in member.fun_exp.args]
+            if len(fun_args) == 1:
+                fun_args = fun_args[0]
             aggregate_functions.append(
                 (
                     member.dst_column.value,

--- a/neurolang/relational_algebra_provenance.py
+++ b/neurolang/relational_algebra_provenance.py
@@ -230,7 +230,7 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
             group_columns,
             aggregate_functions,
         )
-        return ProvenanceAlgebraSet(self.walk(operation).value, prov_col)        
+        return ProvenanceAlgebraSet(self.walk(operation).value, prov_col)
 
     @add_match(EquiJoin(ProvenanceAlgebraSet, ..., ProvenanceAlgebraSet, ...))
     def prov_equijoin(self, equijoin):

--- a/neurolang/relational_algebra_provenance.py
+++ b/neurolang/relational_algebra_provenance.py
@@ -217,7 +217,7 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
             FunctionApplicationListMember(
                 FunctionApplication(
                     Constant(sum),
-                    (prov_col,),
+                    (str2columnstr_constant(prov_col),),
                     validate_arguments=False,
                     verify_type=False,
                 ),
@@ -602,7 +602,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
         aggregate_functions = [
             FunctionApplicationListMember(
                 self._semiring_agg_sum(
-                    (projection.relation.provenance_column,)
+                    (str2columnstr_constant(projection.relation.provenance_column),)
                 ),
                 str2columnstr_constant(projection.relation.provenance_column),
             )

--- a/neurolang/relational_algebra_provenance.py
+++ b/neurolang/relational_algebra_provenance.py
@@ -15,14 +15,13 @@ from .expressions import (
     sure_is_not_pattern
 )
 from .relational_algebra import (
-    AggregateFunctionListMember,
     Column,
     ColumnInt,
     ColumnStr,
     ConcatenateConstantColumn,
     EquiJoin,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     Difference,
     GroupByAggregation,
     LeftNaturalJoin,
@@ -215,7 +214,7 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
 
         # aggregate the provenance column grouped by the projection columns
         aggregate_functions = [
-            AggregateFunctionListMember(
+            FunctionApplicationListMember(
                 FunctionApplication(
                     Constant(sum),
                     (prov_col,),
@@ -290,7 +289,7 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
             )
         )
         new_proj_list = extended_proj.projection_list + (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 fun_exp=new_prov_col, dst_column=new_prov_col
             ),
         )
@@ -341,7 +340,7 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
         result = ExtendedProjection(
             tmp_non_prov_result,
             (
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     fun_exp=MUL(
                         tmp_left_prov_col,
                         SUB(
@@ -353,7 +352,7 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
                 ),
             )
             + tuple(
-                ExtendedProjectionListMember(fun_exp=col, dst_column=col)
+                FunctionApplicationListMember(fun_exp=col, dst_column=col)
                 for col in set(res_columns) - {res_prov_col}
             ),
         )
@@ -423,13 +422,13 @@ class RelationalAlgebraProvenanceCountingSolver(ExpressionWalker):
         result = ExtendedProjection(
             tmp_non_prov_result,
             (
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     fun_exp=prov_binary_op(tmp_left_col, tmp_right_col),
                     dst_column=res_prov_col,
                 ),
             )
             + tuple(
-                ExtendedProjectionListMember(fun_exp=col, dst_column=col)
+                FunctionApplicationListMember(fun_exp=col, dst_column=col)
                 for col in set(res_columns) - {res_prov_col}
             ),
         )
@@ -493,7 +492,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
         rap_right_pc = str2columnstr_constant(rap_right.provenance_column)
 
         cols_to_keep = [
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 str2columnstr_constant(c), str2columnstr_constant(c)
             )
             for c in (rap_left.relations.columns + rap_right.relations.columns)
@@ -516,7 +515,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
                 rap_right_r
             ),
             cols_to_keep + [
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     self._semiring_mul(
                         str2columnstr_constant(rap_left.provenance_column),
                         rap_right_pc
@@ -601,7 +600,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
             return projection.relation
 
         aggregate_functions = [
-            AggregateFunctionListMember(
+            FunctionApplicationListMember(
                 self._semiring_agg_sum(
                     (projection.relation.provenance_column,)
                 ),
@@ -752,7 +751,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
         result = ExtendedProjection(
             tmp_non_prov_result,
             (
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     fun_exp=MUL(
                         tmp_left_prov_col,
                         SUB(Constant(1), isnan(tmp_right_prov_col)),
@@ -761,7 +760,7 @@ class RelationalAlgebraProvenanceExpressionSemringSolver(
                 ),
             )
             + tuple(
-                ExtendedProjectionListMember(fun_exp=col, dst_column=col)
+                FunctionApplicationListMember(fun_exp=col, dst_column=col)
                 for col in set(res_columns) - {res_prov_col}
             ),
         )

--- a/neurolang/tests/test_relational_algebra.py
+++ b/neurolang/tests/test_relational_algebra.py
@@ -637,7 +637,7 @@ def test_groupby_aggregate_sum():
         (Constant(ColumnStr("x")), Constant(ColumnStr("y"))),
         [
             FunctionApplicationListMember(
-                FunctionApplication(Constant(sum), ("z",), verify_type=False),
+                FunctionApplication(Constant(sum), (Constant(ColumnStr("z")),), verify_type=False),
                 Constant(ColumnStr("z_sum")),
             )
         ],
@@ -666,7 +666,7 @@ def test_groupby_aggregate_lambda():
         [
             FunctionApplicationListMember(
                 FunctionApplication(
-                    Constant(custom_lambda), ("y"), verify_type=False
+                    Constant(custom_lambda), (Constant(ColumnStr("y")),), verify_type=False
                 ),
                 Constant(ColumnStr("y_min")),
             )

--- a/neurolang/tests/test_relational_algebra.py
+++ b/neurolang/tests/test_relational_algebra.py
@@ -9,7 +9,6 @@ from ..exceptions import NeuroLangException
 from ..expression_walker import ExpressionWalker
 from ..expressions import Constant, FunctionApplication, Symbol
 from ..relational_algebra import (
-    AggregateFunctionListMember,
     EVAL_OP_TO_STR,
     ColumnInt,
     ColumnStr,
@@ -18,7 +17,7 @@ from ..relational_algebra import (
     EliminateTrivialProjections,
     EquiJoin,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     GroupByAggregation,
     Intersection,
     NameColumns,
@@ -529,7 +528,7 @@ def test_extended_projection_divide_columns():
         )
     )
     dst_column = Constant(ColumnStr('z'))
-    proj = ExtendedProjectionListMember(
+    proj = FunctionApplicationListMember(
         Constant(ColumnStr('y')) / Constant(ColumnStr('x')),
         dst_column
     )
@@ -554,10 +553,10 @@ def test_extended_projection_lambda_function():
     extended_proj_op = ExtendedProjection(
         relation,
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(lambda_fun), Constant(ColumnStr("z"))
             ),
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(RelationalAlgebraStringExpression("x")),
                 Constant(ColumnStr("pomme_de_terre"))
             )
@@ -583,7 +582,7 @@ def test_extended_projection_numeric_named_columns():
     extended_proj_op = ExtendedProjection(
         relation,
         (
-            ExtendedProjectionListMember(
+            FunctionApplicationListMember(
                 Constant(ColumnInt(1)),
                 Constant(ColumnStr("pomme_de_terre"))
             ),
@@ -612,7 +611,7 @@ def test_extended_projection_other_relation_length():
             columns=("hello",), iterable=[(i,) for i in range(length)]
         )
     )
-    proj = ExtendedProjectionListMember(
+    proj = FunctionApplicationListMember(
         Constant(ColumnStr("y")) / Constant(len)(r2), Constant(ColumnStr("y"))
     )
     extended_proj_op = ExtendedProjection(r1, (proj, ))
@@ -637,7 +636,7 @@ def test_groupby_aggregate_sum():
         relation,
         (Constant(ColumnStr("x")), Constant(ColumnStr("y"))),
         [
-            AggregateFunctionListMember(
+            FunctionApplicationListMember(
                 FunctionApplication(Constant(sum), ("z",), verify_type=False),
                 Constant(ColumnStr("z_sum")),
             )
@@ -665,7 +664,7 @@ def test_groupby_aggregate_lambda():
         relation,
         (Constant(ColumnStr("x")), Constant(ColumnStr("z"))),
         [
-            AggregateFunctionListMember(
+            FunctionApplicationListMember(
                 FunctionApplication(
                     Constant(custom_lambda), ("y"), verify_type=False
                 ),
@@ -941,11 +940,11 @@ def test_numpy_log():
         )
     )
     projlist = (
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             fun_exp=Constant(RelationalAlgebraStringExpression("x")),
             dst_column=Constant(ColumnStr("x")),
         ),
-        ExtendedProjectionListMember(
+        FunctionApplicationListMember(
             fun_exp=Constant(numpy.log)(Constant(ColumnStr("y"))),
             dst_column=Constant(ColumnStr("z")),
         ),

--- a/neurolang/tests/test_relational_algebra_provenance.py
+++ b/neurolang/tests/test_relational_algebra_provenance.py
@@ -23,7 +23,7 @@ from ..relational_algebra import (
 from ..relational_algebra_provenance import (
     ConcatenateConstantColumn,
     ExtendedProjection,
-    ExtendedProjectionListMember,
+    FunctionApplicationListMember,
     NaturalJoinInverse,
     Projection,
     ProvenanceAlgebraSet,
@@ -135,7 +135,7 @@ def test_naturaljoin():
         ProvenanceAlgebraSet(RnjR, ColumnStr("__provenance__1")),
         tuple(
             [
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     fun_exp=Constant(ColumnStr("__provenance__1"))
                     * Constant(ColumnStr("__provenance__2")),
                     dst_column=Constant(ColumnStr("__provenance__")),
@@ -216,7 +216,7 @@ def test_product():
         ProvenanceAlgebraSet(RnjR, ColumnStr("__provenance__1")),
         tuple(
             [
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     fun_exp=Constant(ColumnStr("__provenance__1"))
                     * Constant(ColumnStr("__provenance__2")),
                     dst_column=Constant(ColumnStr("__provenance__")),
@@ -378,7 +378,7 @@ def test_extended_projection():
         relation,
         tuple(
             [
-                ExtendedProjectionListMember(
+                FunctionApplicationListMember(
                     fun_exp=Constant(ColumnStr("x"))
                     + Constant(ColumnStr("y")),
                     dst_column=Constant(ColumnStr("sum")),


### PR DESCRIPTION
* Add a new RelationalAlgebraOperation class `GroupByAggregation` to represent groupby and aggregate operation.
* Refactor `prov_projection` and `projection_rap` methods in provenance relational algebra to use this intermediary representation instead of calling aggregate directly on the relations.
* Refactor SemiringSolver to override default `sum` aggregate function.

Allows for performance optimization of spatial prior calculation in probabilistic case :

### Performance before refactoring

[ 50.00%] ··· spatial.TimeSpatialPriorSmoothing.time_spatial_prior_smoothing                                                      1/8 failed
[ 50.00%] ··· ======= ========= =========
              --         probabilistic   
              ------- -------------------
               bound     True     False  
              ======= ========= =========
                 1     5.09±0s   1.78±0s 
                 2     18.9±0s   3.11±0s 
                 4     2.14±0m   15.8±0s 
                 8      failed   2.41±0m 
              ======= ========= =========

### Performance after refactoring

[ 50.00%] ··· spatial.TimeSpatialPriorSmoothing.time_spatial_prior_smoothing                                                      1/8 failed
[ 50.00%] ··· ======= ========= =========
              --         probabilistic   
              ------- -------------------
               bound     True     False  
              ======= ========= =========
                 1     2.36±0s   1.71±0s 
                 2     6.18±0s   3.24±0s 
                 4     39.0±0s   15.8±0s 
                 8      failed   2.44±0m 
              ======= ========= =========

