### PR TITLE
Add try/finally in sure_is_not_pattern context

### DIFF
--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -53,11 +53,13 @@ def sure_is_not_pattern():
     with _lock:
         n = _sure_is_not_pattern.get(thread_id, 0)
         _sure_is_not_pattern[thread_id] = n + 1
-    yield
-    with _lock:
-        _sure_is_not_pattern[thread_id] -= 1
-        if _sure_is_not_pattern[thread_id] == 0:
-            del _sure_is_not_pattern[thread_id]
+    try:
+        yield
+    finally:
+        with _lock:
+            _sure_is_not_pattern[thread_id] -= 1
+            if _sure_is_not_pattern[thread_id] == 0:
+                del _sure_is_not_pattern[thread_id]
 
 
 @contextmanager
@@ -68,9 +70,11 @@ def sure_is_not_pattern_():
 
     with _lock:
         _sure_is_not_pattern[thread_id] = True
-    yield
-    with _lock:
-        del _sure_is_not_pattern[thread_id]
+    try:
+        yield
+    finally:
+        with _lock:
+            del _sure_is_not_pattern[thread_id]
 
 
 def type_validation_value(value, type_):


### PR DESCRIPTION
The `sure_is_not_pattern` context manager should wrap the yield statement in a try/finally to make sure that the thread count number is always decreased.

This fixes the recurring `The value Ellipsis does not correspond to the type <class 'int'>` which we've been having. Some exceptions were happening in another test within the `sure_is_not_pattern` context, so the thread count was not being decreased, and all subsequent expressions were treated as not patterns, even when they should be.

The reason the exceptions were sometimes happening, and sometimes not, is because of the flaky tests in `test_probabilistic_solvers.py` which valentin marked as `pytest.mark.xfails`.

From what i could see, there is an issue in these tests when using the SDDWMCSemiRingSolver. At some point we do an extended projection with `SDDWMCSemiRingSolver.get_new_bernoulli_variable`, which raises an exception `ValueError('Number of available literals is 5 < 6')`.

The `extended_projection` in `relational_algebra.py` is wrapped with a `sure_is_not_pattern` context

```python
with sure_is_not_pattern():
    result = relation.value.extended_projection(eval_expressions)
```

So the exception from the wmc_solver in the extended projection would cause the count of threads in `_sure_is_not_pattern` to not go back down to 0, which in turn would cause all new expressions to not be treated as patterns.