### PR TITLE
Workaround for complex Expression as dict key issue

### DIFF
--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -434,10 +434,17 @@ class Symbol(NonConstant):
         self.is_fresh = False
 
     def __eq__(self, other):
-        return (
-            hash(self) == hash(other) and
-            (isinstance(other, Symbol) or isinstance(other, str))
-         )
+        if hash(self) != hash(other):
+            return False
+
+        if isinstance(other, str):
+            other_str = other
+        elif isinstance(other, Symbol):
+            other_str = other.name
+        else:
+            return False
+
+        return self.name == other_str
 
     def __hash__(self):
         return hash(self.name)
@@ -565,10 +572,10 @@ class Constant(Expression):
             warn('Making a comparison with types needed to be inferred')
 
         if isinstance(other, Expression):
-            if isinstance(other, Constant):
-                value_equal = other.value == self.value
-            else:
-                value_equal = hash(other) == hash(self)
+            value_equal = (
+                isinstance(other, Constant) and
+                (other.value == self.value)
+            )
 
             return value_equal and (
                 is_leq_informative(self.type, other.type) or
@@ -577,7 +584,8 @@ class Constant(Expression):
         else:
             return (
                 hash(other) == hash(self) and
-                type_validation_value(other, self.type)
+                type_validation_value(other, self.type) and
+                self.value == other
             )
 
     def __hash__(self):

--- a/neurolang/probabilistic/dalvi_suciu_lift.py
+++ b/neurolang/probabilistic/dalvi_suciu_lift.py
@@ -8,6 +8,7 @@ from .. import relational_algebra_provenance as rap
 from ..datalog.expression_processing import (
     UnifyVariableEqualities,
     enforce_conjunction,
+    extract_logic_predicates,
     flatten_query,
 )
 from ..datalog.translate_to_named_ra import TranslateToNamedRA
@@ -389,13 +390,7 @@ def separator_variable_plan(expression, separator_variables, symbol_table):
     for v in existentials_to_add:
         expression = ExistentialPredicate(v, expression)
     return rap.Projection(
-        rap.Projection(
-            dalvi_suciu_lift(expression, symbol_table),
-            tuple(
-                str2columnstr_constant(v.name)
-                for v in (variables_to_project | separator_variables)
-            )
-        ),
+        dalvi_suciu_lift(expression, symbol_table),
         tuple(
             str2columnstr_constant(v.name)
             for v in variables_to_project
@@ -547,26 +542,31 @@ def inclusion_exclusion_conjunction(expression, symbol_table):
 
 
 def _formulas_weights(formula_powerset):
-    formula_containments = {
-        formula: set()
+    # Using list set instead of a dictionary
+    # due to a strange bug in dictionary lookups with Expressions
+    # as keys
+    formula_containments = [
+        set()
         for formula in formula_powerset
-    }
-    # temporary fix for key not in dict issue
-    tmp_fix_dict_get = lambda k: next(
-        v for f, v in formula_containments.items() if f == k
-    )
-    for i, f0 in enumerate(formula_powerset):
-        for f1 in formula_powerset[i + 1:]:
-            for c0, c1 in ((f0, f1), (f1, f0)):
-                if c1 not in tmp_fix_dict_get(f0) and is_contained(c0, c1):
-                    formula_containments[c0].add(c1)
-                    formula_containments[c0] |= (
-                        formula_containments[c1] -
-                        {c0}
-                    )
-                    break
+    ]
 
-    formulas_weights = mobius_weights(formula_containments)
+    for i, f0 in enumerate(formula_powerset):
+        for j, f1 in enumerate(formula_powerset[i + 1:], start=i + 1):
+            for i0, c0, i1, c1 in ((i, f0, j, f1), (j, f1, i, f0)):
+                if (
+                    c0 not in formula_containments[i1] and
+                    is_contained(c0, c1)
+                ):
+                    formula_containments[i0] |= (
+                        {c1} | formula_containments[i1] - {c0}
+                    )
+
+    fcs = {
+        formula: containment
+        for formula, containment in
+        zip(formula_powerset, formula_containments)
+    }
+    formulas_weights = mobius_weights(fcs)
     return formulas_weights
 
 
@@ -584,22 +584,17 @@ def mobius_function(formula, formula_containments, known_weights=None):
         known_weights = dict()
     if formula in known_weights:
         return known_weights[formula]
-    # temporary fix for key not in dict issue
-    tmp_fix_dict_get = lambda k: next(
-        v for f, v in formula_containments.items() if f == k
-    )
-    res = -sum(
-        (
-            known_weights.setdefault(
+    res = -1
+    for f in formula_containments[formula]:
+        weight = known_weights.setdefault(
+            f,
+            mobius_function(
                 f,
-                mobius_function(f, formula_containments)
+                formula_containments, known_weights=known_weights
             )
-            for f in tmp_fix_dict_get(formula)
-            if f != formula
-        ),
-        -1
-    )
-    return res
+        )
+        res += weight
+    return -res
 
 
 def powerset(iterable):

--- a/neurolang/probabilistic/dalvi_suciu_lift.py
+++ b/neurolang/probabilistic/dalvi_suciu_lift.py
@@ -538,7 +538,10 @@ def inclusion_exclusion_conjunction(expression, symbol_table):
         if weight != 0
     ))
 
-    return rap.WeightedNaturalJoin(tuple(new_formulas), weights)
+    return rap.WeightedNaturalJoin(
+        tuple(new_formulas),
+        tuple(Constant[int](w) for w in weights)
+    )
 
 
 def _formulas_weights(formula_powerset):


### PR DESCRIPTION
There is a code section in https://github.com/NeuroLang/NeuroLang/blob/1e55827573037bea541240654c6ae9e2bbb68e56/neurolang/probabilistic/dalvi_suciu_lift.py#L549
where there is a bug in which complex logic expressions don't work well as keys of a dictionary providing random results in the equality which we can't reproduce outside the dictionary methods (we don't get why).  This is shown in #652. This PR aims at correcting that by using indexed lists instead of a dictionary and to update the equality of `Symbol` and `Constant` instances as that would have been a part of the issue.