### PR TITLE
Making the parsed syntax closer to submitted paper by Valentin

### DIFF
--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -6,7 +6,7 @@ import tatsu
 from ...datalog import Conjunction, Fact, Implication, Negation, Union
 from ...datalog.constraints_representation import RightImplication
 from ...expressions import Constant, Expression, FunctionApplication, Query, Symbol
-from ...probabilistic.expressions import Condition, ProbabilisticPredicate
+from ...probabilistic.expressions import Condition, ProbabilisticPredicate, PROB
 
 
 GRAMMAR = u"""
@@ -198,6 +198,19 @@ class DatalogSemantics:
                 for arg in ast[2]:
                     arguments.append(arg)
 
+                if PROB in arguments:
+                    ix_prob = arguments.index(PROB)
+                    arguments_not_prob = (
+                        arguments[:ix_prob] +
+                        arguments[ix_prob + 1:]
+                    )
+                    prob_arg = PROB(*arguments_not_prob)
+                    arguments = (
+                        arguments[:ix_prob] +
+                        [prob_arg] +
+                        arguments[ix_prob + 1:]
+                    )
+
                 ast = ast[0](*arguments)
             else:
                 ast = ast[0]()
@@ -208,7 +221,7 @@ class DatalogSemantics:
             # Query head has arguments
             arguments = ast[1]
             return Symbol("ans")(*arguments)
-        else :
+        else:
             # Query head has no arguments
             return Symbol("ans")()
 

--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -17,13 +17,14 @@ GRAMMAR = u"""
 
     start = expressions $ ;
 
-    expressions = ( newline ).{ probabilistic_expression | expression };
+    expressions = ( newline ).{ expression };
 
 
-    probabilistic_expression = ( arithmetic_operation | int_ext_identifier ) '::' expression ;
-    expression = rule | constraint | fact;
+    expression = rule | constraint | fact | probabilistic_rule | probabilistic_fact ;
     fact = constant_predicate ;
+    probabilistic_fact = ( arithmetic_operation | int_ext_identifier ) '::' constant_predicate ;
     rule = (head | query) implication (condition | body) ;
+    probabilistic_rule = head '::' ( arithmetic_operation | int_ext_identifier ) implication (condition | body) ;
     constraint = body right_implication head ;
     head = head_predicate ;
     body = conjunction ;
@@ -148,20 +149,14 @@ class DatalogSemantics:
             ast = (ast,)
         return Union(ast)
 
-    def probabilistic_expression(self, ast):
-        probability = ast[0]
-        expression = ast[2]
-
-        if isinstance(expression, Implication):
-            return Implication(
-                ProbabilisticPredicate(probability, expression.consequent),
-                expression.antecedent,
-            )
-        else:
-            raise ValueError("Invalid rule")
-
     def fact(self, ast):
         return Fact(ast)
+
+    def probabilistic_fact(self, ast):
+        return Implication(
+            ProbabilisticPredicate(ast[0], ast[2]),
+            Constant(True),
+        )
 
     def constant_predicate(self, ast):
         return ast[0](*ast[2])
@@ -172,6 +167,15 @@ class DatalogSemantics:
             return Query(ast[0], ast[2])
         else:
             return Implication(ast[0], ast[2])
+
+    def probabilistic_rule(self, ast):
+        head = ast[0]
+        probability = ast[2]
+        body = ast[4]
+        return Implication(
+            ProbabilisticPredicate(probability, head),
+            body,
+        )
 
     def constraint(self, ast):
         return RightImplication(ast[0], ast[2])

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -326,12 +326,23 @@ def test_query():
     )
 
 
-def test_prob():
+def test_prob_implicit():
     B = Symbol("B")
     C = Symbol("C")
     x = Symbol("x")
     y = Symbol("y")
     res = parser("B(x, PROB, y) :- C(x, y)")
+    assert res == Union(
+        (Implication(B(x, PROB(x, y), y), Conjunction((C(x, y),))),)
+    )
+
+
+def test_prob_explicit():
+    B = Symbol("B")
+    C = Symbol("C")
+    x = Symbol("x")
+    y = Symbol("y")
+    res = parser("B(x, PROB(x, y), y) :- C(x, y)")
     assert res == Union(
         (Implication(B(x, PROB(x, y), y), Conjunction((C(x, y),))),)
     )

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -1,9 +1,14 @@
-from neurolang.logic import ExistentialPredicate
 from operator import add, eq, lt, mul, pow, sub, truediv
 
+from neurolang.logic import ExistentialPredicate
+
 from ....datalog import Conjunction, Fact, Implication, Negation, Union
-from ....probabilistic.expressions import Condition, ProbabilisticPredicate
-from ....expressions import Constant, Query, Symbol, FunctionApplication
+from ....expressions import Constant, FunctionApplication, Query, Symbol
+from ....probabilistic.expressions import (
+    PROB,
+    Condition,
+    ProbabilisticPredicate
+)
 from ..standard_syntax import ExternalSymbol, parser
 
 
@@ -308,6 +313,7 @@ def test_existential():
 
     assert res == expected
 
+
 def test_query():
     ans = Symbol("ans")
     B = Symbol("B")
@@ -317,4 +323,15 @@ def test_query():
     res = parser("ans(x) :- B(x, y), C(3, y)")
     assert res == Union(
         (Query(ans(x), Conjunction((B(x, y), C(Constant(3), y)))),)
+    )
+
+
+def test_prob():
+    B = Symbol("B")
+    C = Symbol("C")
+    x = Symbol("x")
+    y = Symbol("y")
+    res = parser("B(x, PROB, y) :- C(x, y)")
+    assert res == Union(
+        (Implication(B(x, PROB(x, y), y), Conjunction((C(x, y),))),)
     )

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -208,7 +208,7 @@ def test_probabilistic_fact():
     d = Symbol("d")
     x = Symbol("x")
     B = Symbol("B")
-    res = parser("exp((-1 * d) / 5.0) :: B(x) :- A(x, d) & (d < 0.8)")
+    res = parser("B(x) :: exp((-1 * d) / 5.0) :- A(x, d) & (d < 0.8)")
     expected = Union(
         (
             Implication(

--- a/neurolang/probabilistic/expressions.py
+++ b/neurolang/probabilistic/expressions.py
@@ -34,7 +34,7 @@ class ProbabilisticPredicate(Definition):
 
     def __repr__(self):
         return "ProbabilisticPredicate{{{} :: {} : {}}}".format(
-            self.probability, self.body, self.type
+            self.body, self.probability, self.type
         )
 
 


### PR DESCRIPTION
Specifically allowing for the syntax
* `A(x, PROB, y) :- C(x, y)` to be translated to `A(x, PROB(x, y), y) :- C(x, y)`
* Should change the order of probabilistic predicates from `f(x)::P(y) :- A(x, y)` to `P(y)::f(x) :- A(x, y)`