### PR TITLE
Fix NotConjunctiveExpressionNestedPredicates when rule has a condition with a negation

### DIFF
--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -109,11 +109,13 @@ class NeurolangPDL(QueryBuilderDatalog):
         self,
         chase_class: Type[Chase] = Chase,
         probabilistic_solvers: Tuple[Callable] = (
+            small_dichotomy_theorem_based_solver.solve_succ_query,
             dalvi_suciu_lift.solve_succ_query,
             wmc_solve_succ_query,
         ),
         probabilistic_marg_solvers: Tuple[Callable] = (
-            dalvi_suciu_lift.solve_marg_query,
+            small_dichotomy_theorem_based_solver.solve_marg_query,
+            dalvi_suciu_lift.solve_succ_query,
             wmc_solve_marg_query,
         ),
         check_qbased_pfact_tuple_unicity=False,

--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -115,7 +115,7 @@ class NeurolangPDL(QueryBuilderDatalog):
         ),
         probabilistic_marg_solvers: Tuple[Callable] = (
             small_dichotomy_theorem_based_solver.solve_marg_query,
-            dalvi_suciu_lift.solve_succ_query,
+            dalvi_suciu_lift.solve_marg_query,
             wmc_solve_marg_query,
         ),
         check_qbased_pfact_tuple_unicity=False,


### PR DESCRIPTION
The added test raises an exception : 
```
neurolang.exceptions.NotConjunctiveExpressionNestedPredicates: Expression ⋀(¬λ{S{NetworkReported: typing.AbstractSet[typing.Tuple[float, str, str]]}}(S{n: Unknown}, S{s: Unknown}), λ{S{SelectedStudy: typing.AbstractSet[neurolang.type_system.Unknown]}}(S{s: Unknown}), λ{S{TermInStudy: typing.AbstractSet[typing.Tuple[float, str, str]]}}(S{t: Unknown}, S{s: Unknown})) is not conjunctive
```

which should not be raised.

As mentioned on mattermost, after investigation, the issue is related to the way you check whether rules are contained in each other. The `minimize_component_conjunction` gets called with `minimize_component_conjunction( 
 ⋀(¬λ{S{NetworkReported}}(S{n}, S{s}), λ{S{SelectedStudy}}(S{s}))  )` and it splits the rule into different formulas to check wether one is contained in the other. But then you end up evaluating

```
q1_ = Implication{λ{S{fresh_00000055}}(S{s}) ← ¬λ{S{NetworkReported}}(S{n}, S{s})}
q2_ = Implication{λ{S{fresh_00000055}}(S{s}) ← λ{S{SelectedStudy}}(S{s})}
```
qhich raises the exception because q1_ is not conjunctive anymore.