### PR TITLE
Parser syntax simplifications

### DIFF
--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -64,6 +64,7 @@ GRAMMAR = u"""
              | function_application
              | '...' ;
 
+    signed_int_ext_identifier = [ '-' ] int_ext_identifier ;
     int_ext_identifier = identifier | ext_identifier ;
     ext_identifier = '@'identifier;
 
@@ -79,7 +80,7 @@ GRAMMAR = u"""
 
     exponent = literal
              | function_application
-             | int_ext_identifier
+             | signed_int_ext_identifier
              | '(' @:argument ')' ;
 
     literal = number
@@ -294,6 +295,12 @@ class DatalogSemantics:
         else:
             f = ast[0]
         return FunctionApplication(f, args=ast[2])
+
+    def signed_int_ext_identifier(self, ast):
+        if isinstance(ast, Expression):
+            return ast
+        else:
+            return Constant(mul)(Constant(-1), ast[1])
 
     def identifier(self, ast):
         return Symbol(ast)

--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -53,7 +53,7 @@ GRAMMAR = u"""
     constant_predicate = identifier'(' ','.{ literal } ')' ;
 
     negated_predicate = ('~' | '\u00AC' ) predicate ;
-    existential_body = arguments such_that composite_predicate;
+    existential_body = arguments such_that ( conjunction_symbol ).{ predicate }+ ;
     existential_predicate = \
         exists '(' @:existential_body ')' ;
 
@@ -240,7 +240,9 @@ class DatalogSemantics:
 
     def existential_predicate(self, ast):
         exp = ast[2]
-        if isinstance(exp, list):
+        if len(exp) == 1:
+            exp = exp[0]
+        else:
             exp = Conjunction(tuple(exp))
 
         for arg in ast[0]:

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -208,7 +208,7 @@ def test_probabilistic_fact():
     d = Symbol("d")
     x = Symbol("x")
     B = Symbol("B")
-    res = parser("B(x) :: exp((-1 * d) / 5.0) :- A(x, d) & (d < 0.8)")
+    res = parser("B(x) :: exp(-d / 5.0) :- A(x, d) & (d < 0.8)")
     expected = Union(
         (
             Implication(

--- a/neurolang/frontend/datalog/tests/test_parser.py
+++ b/neurolang/frontend/datalog/tests/test_parser.py
@@ -1,16 +1,17 @@
 from operator import add, eq, lt, mul, pow, sub, truediv
 
+import pytest
 from neurolang.logic import ExistentialPredicate
+from tatsu.exceptions import FailedParse
 
 from ....datalog import Conjunction, Fact, Implication, Negation, Union
 from ....expressions import Constant, FunctionApplication, Query, Symbol
 from ....probabilistic.expressions import (
     PROB,
     Condition,
-    ProbabilisticPredicate
+    ProbabilisticPredicate,
 )
 from ..standard_syntax import ExternalSymbol, parser
-
 
 def test_facts():
     res = parser('A(3)')
@@ -290,7 +291,7 @@ def test_existential():
     res = parser("C(x) :- B(x), ∃(s1 st A(s1))")
     assert res == expected
 
-    res = parser("C(x) :- B(x), exists(s1, s2; (A(s1), A(s2)))")
+    res = parser("C(x) :- B(x), exists(s1, s2; A(s1), A(s2))")
 
     expected = Union(
         (
@@ -312,6 +313,9 @@ def test_existential():
     )
 
     assert res == expected
+
+    with pytest.raises(FailedParse):
+        res = parser("C(x) :- B(x), exists(s1; )")
 
 
 def test_query():


### PR DESCRIPTION
Updates for Neurolang parser :
* Make `exp(-d)` work instead of having to write `exp(0-d)`
* Use `exists(s; A(x) & B(s))` instead of having to write `exists(s; (A(x) & B(s)))`
