### PR TITLE
Fix Semantics of Disjoint Project

### DIFF
--- a/neurolang/frontend/tests/test_probabilistic_frontend.py
+++ b/neurolang/frontend/tests/test_probabilistic_frontend.py
@@ -1323,3 +1323,31 @@ def test_simple_disjunction_probfacts():
         ("d", 0.2),
     }
     assert_almost_equal(sol, expected)
+
+
+def test_pchoice_with_both_eqvar_and_free_var():
+    nl = NeurolangPDL()
+    nl.add_probabilistic_choice_from_tuples(
+        [
+            (0.7, "a", "b"),
+            (0.2, "a", "c"),
+            (0.1, "b", "b"),
+        ],
+        name="Pchoice",
+    )
+    nl.add_probabilistic_facts_from_tuples(
+        [
+            (0.9, "a"),
+            (0.2, "b"),
+            (1.0, "c"),
+        ],
+        name="Pfact",
+    )
+    with nl.scope as e:
+        e.Query[e.x, e.PROB(e.x)] = e.Pchoice(e.x, e.y) & e.Pfact(e.y)
+        result = nl.query((e.x, e.prob), e.Query(e.x, e.prob))
+    expected = {
+        ("a", 0.7 * 0.2 + 0.2 * 1.0),
+        ("b", 0.1 * 0.2),
+    }
+    assert_almost_equal(result, expected)

--- a/neurolang/logic/transformations.py
+++ b/neurolang/logic/transformations.py
@@ -471,7 +471,7 @@ class MakeExistentialsImplicit(LogicExpressionWalker):
         return self.walk(expression.body)
 
 
-class MakeExistentialOnVariablesImplicit(LogicExpressionWalker):
+class RemoveExistentialOnVariables(LogicExpressionWalker):
     def __init__(self, variables_to_eliminate):
         self._variables_to_eliminate = variables_to_eliminate
 

--- a/neurolang/logic/transformations.py
+++ b/neurolang/logic/transformations.py
@@ -471,6 +471,19 @@ class MakeExistentialsImplicit(LogicExpressionWalker):
         return self.walk(expression.body)
 
 
+class MakeExistentialOnVariablesImplicit(LogicExpressionWalker):
+    def __init__(self, variables_to_eliminate):
+        self._variables_to_eliminate = variables_to_eliminate
+
+    @add_match(ExistentialPredicate)
+    def existential(self, expression):
+        body = self.walk(expression.body)
+        if expression.head in self._variables_to_eliminate:
+            return body
+        else:
+            return ExistentialPredicate(expression.head, body)
+
+
 def convert_to_pnf_with_cnf_matrix(expression):
     walker = ChainedWalker(
         EliminateImplications,

--- a/neurolang/probabilistic/dalvi_suciu_lift.py
+++ b/neurolang/probabilistic/dalvi_suciu_lift.py
@@ -285,17 +285,12 @@ def disjoint_project_conjunctive_query(conjunctive_query, symbol_table):
             for atom in atoms_with_constants_in_all_key_positions
         )
     )
-    symbol_table = symbol_table.copy()
     for atom in atoms_with_constants_in_all_key_positions:
         if not isinstance(symbol_table[atom.functor], ProbabilisticChoiceSet):
             raise NeuroLangException(
                 "Any atom with constants in all its key positions should be "
                 "a probabilistic choice atom"
             )
-        symbol_table[atom.functor] = ProbabilisticFactSet(
-            symbol_table[atom.functor].relation,
-            symbol_table[atom.functor].probability_column,
-        )
     conjunctive_query = add_existentials_except(
         query, free_variables | nonkey_variables
     )

--- a/neurolang/probabilistic/dalvi_suciu_lift.py
+++ b/neurolang/probabilistic/dalvi_suciu_lift.py
@@ -332,14 +332,11 @@ def disjoint_project_disjunctive_query(disjunctive_query, symbol_table):
 def _get_disjuncts_containing_atom_with_all_key_attributes(ucq, symbol_table):
     matching_disjuncts = set()
     for disjunct in ucq.formulas:
-        rewritten_ucq = MakeExistentialsImplicit().walk(disjunct)
-        rewritten_ucq = CollapseDisjunctions().walk(rewritten_ucq)
-        rewritten_ucq = GuaranteeConjunction().walk(rewritten_ucq)
         if any(
             is_probabilistic_atom_with_constants_in_all_key_positions(
                 atom, symbol_table
             )
-            for atom in rewritten_ucq.formulas
+            for atom in extract_logic_atoms(disjunct)
         ):
             matching_disjuncts.add(disjunct)
     return matching_disjuncts

--- a/neurolang/probabilistic/dalvi_suciu_lift.py
+++ b/neurolang/probabilistic/dalvi_suciu_lift.py
@@ -40,7 +40,7 @@ from ..logic.transformations import (
     CollapseDisjunctions,
     GuaranteeConjunction,
     MakeExistentialsImplicit,
-    MakeExistentialOnVariablesImplicit,
+    RemoveExistentialOnVariables,
     RemoveTrivialOperations,
 )
 from ..relational_algebra import (
@@ -290,7 +290,7 @@ def disjoint_project_conjunctive_query(conjunctive_query, symbol_table):
                 "a probabilistic choice atom"
             )
     conjunctive_query = (
-        MakeExistentialOnVariablesImplicit(nonkey_variables)
+        RemoveExistentialOnVariables(nonkey_variables)
         .walk(conjunctive_query)
     )
     plan = dalvi_suciu_lift(conjunctive_query, symbol_table)

--- a/neurolang/probabilistic/query_resolution.py
+++ b/neurolang/probabilistic/query_resolution.py
@@ -200,13 +200,9 @@ def compute_probabilistic_solution(
             relation = _solve_within_language_prob_query(
                 cpl, rule, succ_prob_solver, marg_prob_solver
             )
-        else:
-            relation = _solve_for_probabilistic_rule(
-                cpl, rule, succ_prob_solver
+            solution[rule.consequent.functor] = Constant[AbstractSet](
+                relation.value.to_unnamed()
             )
-        solution[rule.consequent.functor] = Constant[AbstractSet](
-            relation.value.to_unnamed()
-        )
     return solution
 
 


### PR DESCRIPTION
Simply removing the conversion of the ProbabilisticChoiceSet to a
ProbabilisticFactSet suffices.

The following code at line 294 of `dalvi_suciu_lift.py`

```python
conjunctive_query = add_existentials_except(
    query, free_variables | nonkey_variables
)
```

already makes sure that only existential variables that are not projected out
by the disjoint project rule are reintroduced before subsequent calls to
`dalvi_suciu_lift`
