### PR TITLE
Make the neuro-server command build the frontend app on startup

### DIFF
--- a/neurolang/utils/server/README.md
+++ b/neurolang/utils/server/README.md
@@ -25,6 +25,8 @@ from the `neurolang-web` directory. This command will process the various javasc
 
 The backend [server application](app.py) is configured to serve static files from this directory, so that if you build the frontend application with `npm run build -- --mode dev` and then start the backend server, you should be able to see the built frontend application by navigating to [http://localhost:8888/](http://localhost:8888/) (note the port, 8888, which is the one for the tornado server and not the one used by npm's development frontend server) (also note that we build the application with a specific mode `-- --mode dev`, since by default running `npm run build` will build the application for production, replacing the base api url with the url for the production server, i.e. `http://neurolang-u18.saclay.inria.fr, which would not work on a local machine).
 
+For convenience, if neurolang was installed in editable mode, running the tornado server (using `neuro-server` command or `python -m neurolang.utils.server.app`) will first trigger an execution of the `npm install & npm run build -- --mode dev` command. The built application will then be available from [http://localhost:8888/](http://localhost:8888/).
+
 ## Development
 
 Once Neurolang has been installed in a python environment, the server can be started by running

--- a/neurolang/utils/server/README.md
+++ b/neurolang/utils/server/README.md
@@ -25,7 +25,7 @@ from the `neurolang-web` directory. This command will process the various javasc
 
 The backend [server application](app.py) is configured to serve static files from this directory, so that if you build the frontend application with `npm run build -- --mode dev` and then start the backend server, you should be able to see the built frontend application by navigating to [http://localhost:8888/](http://localhost:8888/) (note the port, 8888, which is the one for the tornado server and not the one used by npm's development frontend server) (also note that we build the application with a specific mode `-- --mode dev`, since by default running `npm run build` will build the application for production, replacing the base api url with the url for the production server, i.e. `http://neurolang-u18.saclay.inria.fr, which would not work on a local machine).
 
-For convenience, if neurolang was installed in editable mode, running the tornado server (using `neuro-server` command or `python -m neurolang.utils.server.app`) will first trigger an execution of the `npm install & npm run build -- --mode dev` command. The built application will then be available from [http://localhost:8888/](http://localhost:8888/).
+For convenience, if neurolang was installed from source and npm is available in your path, the setup.py script builds the frontend by calling the `npm install & npm run build -- --mode dev` command. Once you start the tornado server (using `neuro-server` command or `python -m neurolang.utils.server.app`), the built application will then be available from [http://localhost:8888/](http://localhost:8888/).
 
 ## Development
 

--- a/neurolang/utils/server/app.py
+++ b/neurolang/utils/server/app.py
@@ -60,9 +60,8 @@ class Application(tornado.web.Application):
         uuid_pattern = (
             r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         )
-        static_path = os.path.join(
-            os.path.dirname(__file__), "neurolang-web/dist"
-        )
+        static_path = str(Path(__file__).resolve().parent / "neurolang-web" / "dist")
+        print(f"Serving static files from {static_path}")
 
         handlers = [
             (r"/v1/empty", EmptyHandler),

--- a/neurolang/utils/server/app.py
+++ b/neurolang/utils/server/app.py
@@ -3,8 +3,6 @@ import json
 import logging
 import os
 import os.path
-import shutil
-import subprocess
 import sys
 from concurrent.futures import Future
 from io import BytesIO
@@ -514,74 +512,9 @@ def setup_logs():
     LOG.setLevel(logging.DEBUG)
 
 
-def npm_build():
-    """
-    Execute the `npm run build` command to build the frontend javascript
-    application.
-
-    The `npm run build` command will create the html and js files which
-    constitute the frontend application and put them in the
-    `neurolang-web/dist` directory. The tornado server will then serve
-    those files when the user navigates to the default "/" url.
-
-    This method will return without building the application if
-    * npm binary cannot be found
-    * the neurolang-web directory does not exist in this module's parent dir
-    (i.e if neurolang was installed in an environment, the neurolang-web dir
-    is not copied with the python package)
-    * the dist directory already exists in the neurolang-web directory
-
-    This is a convenience method for a local dev setup only, not meant to be
-    used in a production environment. In a production environment the frontend
-    app should be built and served independently from the tornado python app.
-
-    To serve the frontend application using npm without having to build it
-    everytime, use the `npm run dev` command instead. See `Readme.md` file in
-    this module's parent dir.
-    """
-    web_dir = Path(__file__).resolve().parent / "neurolang-web"
-    if not web_dir.exists():
-        LOG.info(
-            f"{web_dir} directory does not exist, probably because neurolang"
-            " is not installed in editable mode. Skipping frontend build."
-        )
-        return
-
-    npm_command = shutil.which("npm")
-    if not npm_command:
-        LOG.warn(
-            "Could not find the npm binary required to build the frontend "
-            "app. NPM is Node.js' package manager and can be installed "
-            "with node from https://nodejs.org/en/download/."
-        )
-        return
-
-    force_build = options.npm_build
-    dist_dir = web_dir / "dist"
-    if dist_dir.exists() and not force_build:
-        LOG.info(
-            "Frontend app dist directory already exists. Not rebuilding."
-            " To force a rebuild use the --npm-build flag."
-        )
-        return
-
-    command = [npm_command, "install"]
-    LOG.info(
-        f"Running command: [{web_dir}]$ {' '.join(command)}",
-    )
-    subprocess.check_call(command, cwd=str(web_dir))
-
-    command = [npm_command, "run", "build", "--", "--mode", "dev"]
-    LOG.info(
-        f"Running command: [{web_dir}]$ {' '.join(command)}",
-    )
-    subprocess.check_call(command, cwd=str(web_dir))
-
-
 def main():
     tornado.options.parse_command_line()
     setup_logs()
-    npm_build()
     data_dir = Path(options.data_dir)
     LOG.info(f"Neurolang data directory set to {data_dir}")
     opts = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,9 @@ server =
 config = neurolang/config/config.ini
 queries = neurolang/utils/server/queries.yaml
 
+[options.package_data]
+neurolang = utils/server/neurolang-web/dist/*, utils/server/neurolang-web/dist/**/*
+
 [options.entry_points]
 console_scripts=
   neuro-server = neurolang.utils.server.app:main

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 import configparser
+import distutils
 import os
 import sys
+import shutil
+import subprocess
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 from setuptools.command.develop import develop
+from setuptools.command.build_py import build_py
 from pathlib import Path
 
 # Workaround for editable install with pip
@@ -15,7 +19,7 @@ import versioneer
 
 def update_config_file():
     """
-    Read the config file in `neurolang/utils/config/config.ini`
+    Read the config file in `neurolang/config/config.ini`
     and update the value for ["RAS"]["Backend"] to dask.
     This config file will then be copied during install as a
     setuptools data_files.
@@ -33,7 +37,9 @@ def update_config_file():
 
 class DevelopCommand(develop):
     """
-    Custom develop option to edit the config file and set
+    Custom develop command.
+
+    - Option to edit the config file and set
     dask-sql as the backend when `--dask` flag is set on install.
 
     Usage
@@ -42,6 +48,15 @@ class DevelopCommand(develop):
     $ python setup.py develop --dask
     or
     $ pip install -e . --install-option='--dask'
+
+    - Option to build the frontend app using the npm_build command
+
+    Usage
+    -----
+    Run
+    $ python setup.py develop --npm-build
+    or
+    $ pip install -e . --install-option='--npm-build'
 
     This will only work when installing a source distribution zip or tarball,
     or installing in editable mode from a source tree. **It will not work when
@@ -52,11 +67,13 @@ class DevelopCommand(develop):
 
     user_options = develop.user_options + [
         ("dask", None, None),
+        ("npm-build", None, "build the frontend html/js app using npm-build"),
     ]
 
     def initialize_options(self):
         develop.initialize_options(self)
         self.dask = None
+        self.npm_build = False
 
     def finalize_options(self):
         develop.finalize_options(self)
@@ -64,12 +81,16 @@ class DevelopCommand(develop):
     def run(self):
         if self.dask:
             update_config_file()
+        if self.npm_build:
+            self.run_command("npm_build")
         develop.run(self)
 
 
 class InstallCommand(install):
     """
-    Custom install option to edit the config file and set
+    Custom install command.
+
+    - Option to edit the config file and set
     dask-sql as the backend when `--dask` flag is set on install.
 
     Usage
@@ -78,6 +99,15 @@ class InstallCommand(install):
     $ python setup.py install --dask
     or
     $ pip install . --install-option='--dask'
+
+    - Option to build the frontend app using the npm_build command
+
+    Usage
+    -----
+    Run
+    $ python setup.py install --npm-build
+    or
+    $ pip install . --install-option='--npm-build'
 
     This will only work when installing a source distribution zip or tarball,
     or installing in editable mode from a source tree. **It will not work when
@@ -88,11 +118,13 @@ class InstallCommand(install):
 
     user_options = install.user_options + [
         ("dask", None, None),
+        ("npm-build", None, "build the frontend html/js app using npm-build"),
     ]
 
     def initialize_options(self):
         install.initialize_options(self)
         self.dask = None
+        self.npm_build = False
 
     def finalize_options(self):
         install.finalize_options(self)
@@ -100,7 +132,77 @@ class InstallCommand(install):
     def run(self):
         if self.dask:
             update_config_file()
+        if self.npm_build:
+            self.run_command("npm_build")
         install.run(self)
+
+
+class NPMBuildCommand(distutils.cmd.Command):
+    """Run the npm build command"""
+
+    description = "run the npm build command for the web server"
+    user_options = []
+
+    def initialize_options(self):
+        """Set default values for options."""
+        pass
+
+    def finalize_options(self):
+        """Post-process options."""
+        pass
+
+    def run(self):
+        """Run the npm build command"""
+        npm_command = shutil.which("npm")
+        if not npm_command:
+            raise OSError(
+                "Could not find the npm binary required to build the frontend "
+                "app. NPM is Node.js' package manager and can be installed "
+                "with node from https://nodejs.org/en/download/."
+            )
+
+        web_dir = (
+            Path(__file__).resolve().parent
+            / "neurolang"
+            / "utils"
+            / "server"
+            / "neurolang-web"
+        )
+        if not web_dir.exists():
+            raise OSError(f"{web_dir} directory does not exist.")
+
+        command = [npm_command, "install"]
+        self.announce(
+            f"Running command: [{web_dir}]$ {' '.join(command)}",
+            level=distutils.log.INFO,
+        )
+        subprocess.check_call(
+            command, cwd="neurolang/utils/server/neurolang-web"
+        )
+
+        command = [npm_command, "run", "build", "--", "--mode", "dev"]
+        self.announce(
+            f"Running command: [{web_dir}]$ {' '.join(command)}",
+            level=distutils.log.INFO,
+        )
+        subprocess.check_call(
+            command, cwd="neurolang/utils/server/neurolang-web"
+        )
+
+
+class BuildPyCommand(build_py):
+    """Customize the build command and add the npm build"""
+
+    def run(self):
+        """Run the npm build before the normal build"""
+        try:
+            self.run_command("npm_build")
+        except OSError as e:
+            self.announce(
+                f"Skipping build of frontend app because: {e}.",
+                level=distutils.log.WARN,
+            )
+        build_py.run(self)
 
 
 if __name__ == "__main__":
@@ -112,5 +214,7 @@ if __name__ == "__main__":
         cmdclass={
             "install": InstallCommand,
             "develop": DevelopCommand,
+            "npm_build": NPMBuildCommand,
+            "build_py": BuildPyCommand,
         },
     )


### PR DESCRIPTION
When starting neurolang's tornado application server, build the javascript/html files if needed by executing the `npm run build` command.

This will only work if neurolang was installed in `editable` or `dev` mode, as it's intended for a local dev setup only.