### PR TITLE
Implement set destroy operation on the relational algebra sets

### DIFF
--- a/neurolang/relational_algebra/relational_algebra.py
+++ b/neurolang/relational_algebra/relational_algebra.py
@@ -999,31 +999,10 @@ class RelationalAlgebraSolver(ew.ExpressionWalker):
                 "set's columns"
             )
 
-        cols = relation.columns
-        set_type = type(relation)
-        if not isinstance(dst_columns, tuple):
-            dst_columns = (dst_columns,)
-        dst_cols = cols + tuple(d for d in dst_columns if d not in cols)
-        result_set = set_type(columns=dst_cols)
-        if len(cols) > 0:
-            row_group_iterator = (t for _, t in relation.groupby(cols))
-        else:
-            row_group_iterator = (relation,)
-        for t in row_group_iterator:
-            destroyed_set = set_type(columns=dst_columns)
-            for row in t:
-                row_set = set_type(
-                    columns=dst_columns,
-                    iterable=getattr(row, src_column)
-                )
-                destroyed_set = destroyed_set | row_set
-            new_set = (
-                t
-                .projection(*cols)
-                .naturaljoin(destroyed_set)
-            )
-            result_set = result_set | new_set
-        return self._build_relation_constant(result_set)
+        new_relation = relation.explode(src_column, dst_columns)
+        return self._build_relation_constant(
+            new_relation
+        )
 
     @ew.add_match(ReplaceNull(Constant, Constant, Constant))
     def replace_null(self, expression):

--- a/neurolang/utils/relational_algebra_set/abstract.py
+++ b/neurolang/utils/relational_algebra_set/abstract.py
@@ -186,6 +186,10 @@ class NamedRelationalAlgebraFrozenSet(RelationalAlgebraFrozenSet):
         pass
 
     @abstractmethod
+    def explode(self, src_column):
+        pass
+
+    @abstractmethod
     def __iter__(self):
         pass
 

--- a/neurolang/utils/relational_algebra_set/abstract.py
+++ b/neurolang/utils/relational_algebra_set/abstract.py
@@ -186,7 +186,7 @@ class NamedRelationalAlgebraFrozenSet(RelationalAlgebraFrozenSet):
         pass
 
     @abstractmethod
-    def explode(self, src_column):
+    def explode(self, src_column, dst_columns):
         pass
 
     @abstractmethod

--- a/neurolang/utils/relational_algebra_set/dask_sql.py
+++ b/neurolang/utils/relational_algebra_set/dask_sql.py
@@ -816,6 +816,24 @@ class NamedRelationalAlgebraFrozenSet(
             query, row_types=self.row_types
         )
 
+    def explode(self, src_column):
+        if self._table is None:
+            return type(self)(columns=self.columns, iterable=[])
+
+        sql_dst_column = column(src_column)
+        columns = [
+            c if c != self.sql_columns.get(src_column) else sql_dst_column for c in self.sql_columns 
+        ]
+
+        query = (
+            select(columns)
+            .select_from(self._table).select_from(func.unnest(self.sql_columns.get(src_column)).alias(src_column))
+        )
+
+        return self._create_view_from_query(
+            query, row_types=self.row_types
+        )
+
     def equijoin(self, other, join_indices):
         raise NotImplementedError()
 

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -659,7 +659,7 @@ class NamedRelationalAlgebraFrozenSet(
             new_container = new_container[list(new_columns)]
 
         return self._light_init_same_structure(
-            new_container,
+            new_container.convert_dtypes(),
             might_have_duplicates=True,
             columns=new_columns,
         )

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -632,6 +632,17 @@ class NamedRelationalAlgebraFrozenSet(
             columns=self.columns,
         )
 
+    def explode(self, src_column):
+        if self._container is None:
+            return self.copy()
+        
+        new_container = self._container.explode(src_column, ignore_index=True)
+        return self._light_init_same_structure(
+            new_container,
+            might_have_duplicates=True,
+            columns=self.columns,
+        )
+
     def cross_product(self, other):
         res = self._dee_dum_product(other)
         if res is not None:

--- a/neurolang/utils/tests/test_relational_algebra_set.py
+++ b/neurolang/utils/tests/test_relational_algebra_set.py
@@ -1133,6 +1133,28 @@ def test_replace_null(ra_module):
     assert relation.replace_null("y", -1) == expected
 
 
+def test_explode(ra_module):
+    data = [
+        (5, frozenset({(1, 2), (5, 6)}), "dog"),
+        (10, frozenset({(5, 6), (8, 9)}), "cat"),
+    ]
+    relation = ra_module.NamedRelationalAlgebraFrozenSet(
+        columns=["x", "y", "z"],
+        iterable=data,
+    )
+
+    expected = ra_module.NamedRelationalAlgebraFrozenSet(
+        columns=["x", "y", "z"],
+        iterable=[
+            (5, (1, 2), "dog"),
+            (5, (5, 6), "dog"),
+            (10, (5, 6), "cat"),
+            (10, (8, 9), "cat"),
+        ],
+    )
+    assert relation.explode("y") == expected
+
+
 def test_aggregate_repeated_group_column(ra_module):
     relation = ra_module.NamedRelationalAlgebraFrozenSet(
         columns=["x", "y"],

--- a/neurolang/utils/tests/test_relational_algebra_set.py
+++ b/neurolang/utils/tests/test_relational_algebra_set.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import pytest
 
 from ..relational_algebra_set import (
@@ -1135,8 +1136,8 @@ def test_replace_null(ra_module):
 
 def test_explode(ra_module):
     data = [
-        (5, frozenset({(1, 2), (5, 6)}), "dog"),
-        (10, frozenset({(5, 6), (8, 9)}), "cat"),
+        (5, frozenset({1, 2, 5, 6}), "dog"),
+        (10, frozenset({5, 9}), "cat"),
     ]
     relation = ra_module.NamedRelationalAlgebraFrozenSet(
         columns=["x", "y", "z"],
@@ -1146,13 +1147,19 @@ def test_explode(ra_module):
     expected = ra_module.NamedRelationalAlgebraFrozenSet(
         columns=["x", "y", "z"],
         iterable=[
-            (5, (1, 2), "dog"),
-            (5, (5, 6), "dog"),
-            (10, (5, 6), "cat"),
-            (10, (8, 9), "cat"),
+            (5, 1, "dog"),
+            (5, 2, "dog"),
+            (5, 5, "dog"),
+            (5, 6, "dog"),
+            (10, 5, "cat"),
+            (10, 9, "cat"),
         ],
     )
-    assert relation.explode("y") == expected
+    result = relation.explode("y")
+    print(result)
+    assert result == expected
+    if hasattr(result, "set_row_type"):
+        assert result.set_row_type == Tuple[int, int, str]
 
 
 def test_aggregate_repeated_group_column(ra_module):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
   scipy
   nibabel
   nilearn>=0.5.0
-  pandas>=0.23.4,<1.2.0
+  pandas>=1.2.0
   pysdd @ git+https://github.com/wannesm/PySDD.git#egg=PySDD
   tatsu
   scikit-learn


### PR DESCRIPTION
Simplify implementation of the set destroy relational algebra operation by moving its implementation on relational algebra sets and taking advantage of the `explode` method on pandas and dask dataframes.

Some extra column manipulations were added to the `explode` method of RA sets to keep the behaviour of the set destroy operation identical.
Also, for the dask-sql implementation, there is no SQL operation which corresponds to `explode`. There is an `unnest` operation, but it is only valid when applied to lists, not to table columns. It seemed rather difficult to extend the SQL language for Calcite to understand this new operation, so instead the `explode` method of dask-sql sets directly calls explode on the underlying dask dataframe and creates a new result set from it.

Finally, I updated the dependency on pandas to > 1.2.0, since the explode method only works with sets from pandas 1.2.0, and the previous restriction on pandas being < 1.2.0 in neurolang was because of dask-sql using a version of dask which required it, but not anymore ..