### PR TITLE
Allow constants in query expressions for probabilistic neurolang

### DIFF
--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -454,10 +454,16 @@ class NeurolangPDL(QueryBuilderDatalog):
             )
         query_solution = solution[pred_symb].value.unwrap()
         query_row_type = solution[pred_symb].value.row_type
+        constant_selection = {
+            i: c.value for i, c in enumerate(predicate.expression.args)
+            if isinstance(c, ir.Constant)
+        }
+        if constant_selection:
+            query_solution = query_solution.selection(constant_selection)
         cols = list(
-            arg.name
+            arg.name if isinstance(arg, ir.Symbol)
+            else ir.Symbol.fresh().name
             for arg in predicate.expression.args
-            if isinstance(arg, ir.Symbol)
         )
         query_solution = NamedRelationalAlgebraFrozenSet(cols, query_solution)
         query_solution = query_solution.projection(

--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -239,6 +239,21 @@ def test_query_wrong_head_arguments():
             neurolang.query((e.x, e.y, e.z), e.q(e.x, e.y))
 
 
+def test_query_with_constant():
+    neurolang = frontend.NeurolangDL()
+
+    s = neurolang.add_tuple_set(
+        (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"))
+    )
+
+    with neurolang.scope as e:
+        e.q[e.x, e.y] = s(e.x, e.y)
+        res = neurolang.query((e.y), e.q("a", e.y))
+
+    print(res.to_unnamed())
+    assert res.to_unnamed() == {("b",), ("c",), ("d",)}
+
+
 @pytest.mark.skip()
 def test_load_spherical_volume_first_order():
     neurolang = frontend.RegionFrontend()

--- a/neurolang/frontend/tests/test_probabilistic_frontend.py
+++ b/neurolang/frontend/tests/test_probabilistic_frontend.py
@@ -311,6 +311,25 @@ def test_solve_boolean_query():
             nl.query((e.p), e.ans[e.p])
 
 
+def test_solve_query_with_constant():
+    nl = NeurolangPDL()
+    P = nl.add_probabilistic_choice_from_tuples(
+        {(0.2, "a"), (0.3, "b"), (0.5, "c")}, name="P"
+    )
+    Q = nl.add_uniform_probabilistic_choice_over_set(
+        [("a",), ("d",), ("c",)], name="Q"
+    )
+    with nl.scope as e:
+        e.ans[e.x, e.PROB(e.x)] = P[e.x] & Q[e.x]
+        res = nl.query((e.p), e.ans["a", e.p])
+    expected = RelationalAlgebraFrozenSet(
+        [
+            (0.2 * 1/3,),
+        ]
+    )
+    assert_almost_equal(res, expected)
+
+
 def test_solve_complex_stratified_query():
     """
     R(1, 2) : 0.3


### PR DESCRIPTION
Update `_restrict_to_query_solution` method in probabilistic frontend to handle constants in query predicates by adding selection and projecting on non-constant columns.