### PR TITLE
[FEAT] Autocompletion : backend

### DIFF
--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -317,7 +317,7 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
             self.program_ir.walk(program)
         else:
             self.program_ir.walk(intermediate_representation)
-        res = self.datalog_parser(autocompletion_code, True)
+        res = self.datalog_parser(autocompletion_code, None, None, True)
         return res
 
     def query(

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -259,6 +259,67 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
                 )
             )
 
+    def compute_datalog_program_for_autocompletion(
+            self, code: str, autocompletion_code
+    ) -> Dict:
+        """
+        Computes a Datalog program in classical syntax.
+        Returns the next accepted tokens of the program.
+
+        Parameters
+        ----------
+        code : string
+            Datalog program.
+        autocompletion_code : str
+            Datalog program for autocompletion.
+
+        Examples
+        --------
+        >>> p_ir = DatalogProgram()
+        >>> nl = QueryBuilderDatalog(program_ir=p_ir)
+        >>> prog_complete = '''
+        ...        l2(x, y) :- l(x, y), (x == y)
+        ...        ans(x) :- l2(x, y)
+        ...        '''
+        >>> prog = '''
+        ...        l2(x, y) :- l(x, y), (x == y)
+        ...        ans(x) :-
+        ...        '''
+        >>> with nl.environment as e:
+        ...     q = nl.compute_datalog_program_for_autocompletion(prog_complete, prog)
+        >>> q
+        ... {
+        ...     'Signs': {'@', '∃', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
+        ...     'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(),
+        ...     'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'False', 'True'},
+        ...     'Expression symbols': set(), 'Python string': set(),
+        ...     'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(),
+        ...     'functions': set(), 'base symbols': set(), 'query symbols': set()
+        ... }
+        """
+        # All the following code before return is mandatory to retrieve
+        # the query symbols without actually running the query
+        intermediate_representation = self.datalog_parser(code)
+        queries = [
+            rule
+            for rule in intermediate_representation.formulas
+            if isinstance(rule, ir.Query)
+        ]
+        if len(queries) == 1:
+            self.frontend_translator.walk(queries[0])
+            program = logic.Union(
+                [
+                    rule
+                    for rule in intermediate_representation.formulas
+                    if not isinstance(rule, ir.Query)
+                ]
+            )
+            self.program_ir.walk(program)
+        else:
+            self.program_ir.walk(intermediate_representation)
+        res = self.datalog_parser(autocompletion_code, interactive=True)
+        return res
+
     def query(
         self, *args
     ) -> Union[bool, RelationalAlgebraFrozenSet, fe.Symbol]:
@@ -408,8 +469,10 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
 
         try:
             with self.scope:
-                magic_query_expression = self.magic_sets_rewrite_program(query_expression)
-                reachable_rules = reachable_code(magic_query_expression, self.program_ir)
+                magic_query_expression = self.magic_sets_rewrite_program(
+                    query_expression)
+                reachable_rules = reachable_code(
+                    magic_query_expression, self.program_ir)
                 solution = self.chase_class(
                     self.program_ir, rules=reachable_rules
                 ).build_chase_solution()
@@ -429,9 +492,9 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         if isinstance(head, tuple):
             row_type = solution_set.value.row_type
             solution_set = NamedRelationalAlgebraFrozenSet(
-                    tuple(s.expression.name for s in head),
-                    solution_set.value.unwrap()
-                )
+                tuple(s.expression.name for s in head),
+                solution_set.value.unwrap()
+            )
             solution_set.row_type = row_type
         return solution_set, functor_orig
 

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -317,7 +317,7 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
             self.program_ir.walk(program)
         else:
             self.program_ir.walk(intermediate_representation)
-        res = self.datalog_parser(autocompletion_code, interactive=True)
+        res = self.datalog_parser(autocompletion_code, True)
         return res
 
     def query(

--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -521,6 +521,33 @@ def test_neurolang_dl_datalog_code_statement():
     }
 
 
+def test_neurolang_dl_datalog_code_statement_autocompletion():
+    neurolang = frontend.NeurolangDL()
+    res = neurolang.compute_datalog_program_for_autocompletion(
+        """
+    A(4, 5)
+    A(5, 6)
+    A(6, 5)
+    five := 5
+    B(x,y) :- A(x, y)
+    B(x,y) :- B(x, z),A(z, y)
+    C(x) :- B(x, y), (y == five)
+    D("x")
+    """,
+        """
+    A(4, 5)
+    A(5, 6)
+    A(6, 5)
+    five := 5
+    B(x,y) :- A(x, y)
+    B(x,y) :- 
+    """
+    )
+    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
+                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'⊥', 'False', '⊤', 'True'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    assert res == expected
+
+
 def test_neurolang_dl_datalog_code_lambda_def():
     neurolang = frontend.NeurolangDL()
     neurolang.execute_datalog_program(

--- a/neurolang/utils/server/queries.py
+++ b/neurolang/utils/server/queries.py
@@ -194,6 +194,81 @@ class NeurolangQueryManager:
                     "[Thread - %s] - Engine of type %s released.", get_ident(), engine_type
                 )
 
+    def _compute_query_autocompletion(
+            self, query: str, autocompletion_query: str, engine_type: str
+    ) -> Dict:
+        """
+        Function executed on a ThreadPoolExecutor worker to compute a query
+        autocompletion against a neurolang engine.
+
+        Parameters
+        ----------
+        query : str
+            the query to retrieve the query symbols
+        autocompletion_query : str
+            the query portion for autocompletion
+        engine_type : str
+            the type of engine on which to execute the query
+
+        Returns
+        -------
+        Dict
+            the result of the query autocompletion
+        """
+        LOG.debug(
+            "[Thread - %s] - Computing query auto-completion...", get_ident())
+        LOG.debug("[Thread - %s] - Query :\n%s", get_ident(), query)
+        # Raise a KeyError if engines are not yet available
+        engine_set = self.engines[engine_type]
+        with engine_set.engine() as engine:
+            LOG.debug(
+                "[Thread - %s] - Engine of type %s acquired.",
+                get_ident(), engine_type
+            )
+            try:
+                with engine.scope:
+                    LOG.debug("[Thread - %s] - Solving query...", get_ident())
+
+                    res = engine.compute_datalog_program_for_autocompletion(
+                        query, autocompletion_query)
+
+                    if 'functions' in res:
+                        for name in engine.symbols:
+                            if not name.startswith("_"):
+                                symbol = engine.symbols[name]
+                                if is_leq_informative(symbol.type, Callable):
+                                    if (name[0].isupper()) or (name.startswith('fresh')):
+                                        res['query symbols'].add(name)
+                                    else:
+                                        res['functions'].add(name)
+                                elif is_leq_informative(symbol.type, AbstractSet):
+                                    res['base symbols'].add(name)
+
+                        res['base symbols'] = sorted(list(res['base symbols']))
+                        res['query symbols'] = sorted(
+                            list(res['query symbols']))
+                        res['functions'] = sorted(list(res['functions']))
+
+                    if 'commands' in res:
+                        rescomm = _get_commands(engine)
+                        res['commands'] = list(rescomm)
+
+                    # Clean toks : remove the keys with empty list
+                    tmp_toks = {k: v for k, v in res.items() if v}
+                    res.clear()
+                    res.update(tmp_toks)
+
+                    return res
+            except Exception as e:
+                LOG.debug(
+                    "[Thread - %s] - Query auto-completion raised %s.", get_ident(), e
+                )
+                raise e
+            finally:
+                LOG.debug(
+                    "[Thread - %s] - Engine of type %s released.", get_ident(), engine_type
+                )
+
     def submit_query(self, uuid: str, query: str, engine_type: str) -> Future:
         """
         Submit a query to one of the available engines / workers.
@@ -219,6 +294,36 @@ class NeurolangQueryManager:
 
         future_res = self.executor.submit(
             self._execute_neurolang_query, query, engine_type
+        )
+        self.results_cache[uuid] = future_res
+        return future_res
+
+    def submit_query_autocompletion(self, uuid: str, query: str, autocompletion_query: str, engine_type: str) -> Future:
+        """
+        Submit a query autocompletion to one of the available engines / workers.
+
+        Parameters
+        ----------
+        uuid : str
+            the uuid for the query.
+        query : str
+            the whole datalog query.
+        autocompletion_query : str
+            the datalog query to autocomplete.
+        engine_type : str
+            the type of engine to use for autocompleting the query.
+
+        Returns
+        -------
+        Future
+            a future result for the query autocompletion.
+        """
+        LOG.debug(
+            "Submitting query for auto-computation with uuid %s to executor pool of %s engines.",
+            uuid, engine_type
+        )
+        future_res = self.executor.submit(
+            self._compute_query_autocompletion, query, autocompletion_query, engine_type
         )
         self.results_cache[uuid] = future_res
         return future_res


### PR DESCRIPTION
--- Summary --------------------------------------------------------------------

A] Implemented the methods involved in the autocompletion functionality and
   their pytest tests
-> Modified files :
   - 'neurolang/frontend/query_resolution_datalog.py'
   - 'neurolang/frontend/tests/test_frontend.py'
   - 'neurolang/utils/server/queries.py'
   - 'neurolang/utils/server/tests/test_queries.py'

--- Details --------------------------------------------------------------------

1/ File neurolang/frontend/query_resolution_datalog.py

Additions :
- compute_datalog_program_for_autocompletion() method

Modifications :
- Minor modifications to be consistent with PEP8 convention

2/ File neurolang/frontend/tests/test_frontend.py

Additions :
- test_neurolang_dl_datalog_code_statement_autocompletion() function

3/ File neurolang/utils/server/queries.py

Additions :

- _compute_query_autocompletion() method
- submit_query_autocompletion() method

Modifications :
- some imports modified to use relative import

4/ File neurolang/utils/server/tests/test_queries.py

Additions :
- test_nqm_computes_autocompletion() function

Modifications :
- some imports modified to use relative import
- minor modifications to be consistent with PEP8 convention