### PR TITLE
[FEATURE] Autocompletion - backend : query resolution

### DIFF
--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -543,7 +543,6 @@ def test_neurolang_dl_datalog_code_statement_autocompletion():
     B(x,y) :- 
     """
     )
-    print(res)
     expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
                 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
     assert res == expected

--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -521,6 +521,34 @@ def test_neurolang_dl_datalog_code_statement():
     }
 
 
+def test_neurolang_dl_datalog_code_statement_autocompletion():
+    neurolang = frontend.NeurolangDL()
+    res = neurolang.compute_datalog_program_for_autocompletion(
+        """
+    A(4, 5)
+    A(5, 6)
+    A(6, 5)
+    five := 5
+    B(x,y) :- A(x, y)
+    B(x,y) :- B(x, z),A(z, y)
+    C(x) :- B(x, y), (y == five)
+    D("x")
+    """,
+        """
+    A(4, 5)
+    A(5, 6)
+    A(6, 5)
+    five := 5
+    B(x,y) :- A(x, y)
+    B(x,y) :- 
+    """
+    )
+    print(res)
+    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
+                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    assert res == expected
+
+
 def test_neurolang_dl_datalog_code_lambda_def():
     neurolang = frontend.NeurolangDL()
     neurolang.execute_datalog_program(

--- a/neurolang/frontend/tests/test_frontend.py
+++ b/neurolang/frontend/tests/test_frontend.py
@@ -543,8 +543,8 @@ def test_neurolang_dl_datalog_code_statement_autocompletion():
     B(x,y) :- 
     """
     )
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'False', '⊤', '⊥', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 

--- a/neurolang/utils/interactive_parsing.py
+++ b/neurolang/utils/interactive_parsing.py
@@ -1,5 +1,3 @@
-# from __future__ import annotations
-
 from dataclasses import dataclass
 from lark import Lark
 from lark.exceptions import UnexpectedCharacters, UnexpectedToken
@@ -9,7 +7,7 @@ from ..exceptions import UnexpectedTokenError
 
 # Code based on https://github.com/MegaIng/lark-autocomplete/blob/master/lark_autocomplete.py
 
-# List of the different categories to by displayed in the frontend.
+# List of the different categories to displayed in the frontend.
 CATEGORIES = [
     'Signs',
     'Numbers',
@@ -121,7 +119,7 @@ class LarkCompleter:
         # Initialise the final accepted tokens dictionary
         accepted_tokens = {}
         for category in CATEGORIES:
-            accepted_tokens[category] = set()
+            accepted_tokens[category] = {"values": set()}
 
         # Get the accepted tokens given by the parser
         parser_accepted_tokens = list(interactive.accepts())
@@ -139,19 +137,20 @@ class LarkCompleter:
             t_pattern = str(terminal.pattern).replace("'", "")
 
             if (t_name == 'CMD_IDENTIFIER'):
-                t_pattern = '<command identifier>'
-                accepted_tokens['commands'] = set()
+                t_pattern = '<cmd_identifier>'
+                accepted_tokens['commands'] = {"values": set()}
             elif (t_name == 'FLOAT'):
                 t_pattern = '<float>'
             elif (t_name == 'IDENTIFIER_REGEXP'):
-                t_pattern = '<identifier regular expression>'
-                accepted_tokens['functions'] = set()
-                accepted_tokens['base symbols'] = set()
-                accepted_tokens['query symbols'] = set()
+                # t_pattern = '<identifier regular expression>'
+                t_pattern = '<identifier_regexp>'
+                accepted_tokens['functions'] = {"values": set()}
+                accepted_tokens['base symbols'] = {"values": set()}
+                accepted_tokens['query symbols'] = {"values": set()}
             elif (t_name == 'INT'):
                 t_pattern = '<integer>'
             elif (t_name == 'PYTHON_STRING'):
-                t_pattern = '<quoted string>'
+                t_pattern = '<string>'
             elif (t_name == 'TEXT'):
                 t_pattern = '<text>'
             else:
@@ -165,9 +164,10 @@ class LarkCompleter:
                 t_pattern = t_pattern.replace(
                     '(?:', '').replace(')', '').split('|')
                 for pattern in t_pattern:
-                    accepted_tokens[TERMINALS_TO_CATEGORIES[t_name]].add(
+                    accepted_tokens[TERMINALS_TO_CATEGORIES[t_name]]["values"].add(
                         pattern)
             else:
-                accepted_tokens[TERMINALS_TO_CATEGORIES[t_name]].add(t_pattern)
+                accepted_tokens[TERMINALS_TO_CATEGORIES[t_name]
+                                ]["values"].add(t_pattern)
 
         return CompleteResult(len(text), "", accepted_tokens)

--- a/neurolang/utils/tests/test_interactive_parsing.py
+++ b/neurolang/utils/tests/test_interactive_parsing.py
@@ -9,8 +9,8 @@ from ...frontend.datalog.standard_syntax import COMPILED_GRAMMAR
 def test_interactive_empty_input():
     completer = LarkCompleter(COMPILED_GRAMMAR)
     res = completer.complete('').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-', '~', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊤', 'True', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
@@ -18,66 +18,66 @@ def test_interactive_facts():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('A').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':=', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '+', '*', '**', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(').token_options
-    expected = {'Signs': {'...', '@', ')', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '...', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A()').token_options
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'←', '.', ':=', ':-', '::'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊥', 'True', 'False', '⊤'}}, 'Expression symbols': {'values': {'←', '::', '.', ':=', ':-'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(3').token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'+', '**', '-', '/', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(3)').token_options
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '¬', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊥', 'False', 'True', '⊤'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A("x"').token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '+', '**', '-', '/'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A("x")').token_options
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊤', 'True', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A("x",').token_options
-    expected = {'Signs': {'@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+                'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = completer.complete("A('x', 3").token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete("A('x', 3,").token_options
-    expected = {'Signs': {'@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+                'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = completer.complete("A('x', 3)").token_options
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('''
     `http://uri#test-fact`("x")
     A("x", 3
     ''').token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
 
@@ -85,128 +85,128 @@ def test_interactive_rules():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('A(x').token_options
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ',', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '/', '**', '+', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x)').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', ':-', ':=', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':-', '::', '←', ':='}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'True', 'False', '⊤', '⊥'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(').token_options
-    expected = {'Signs': {')', '...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {')', '(', '@', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B()').token_options
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'∧', '∃', '(', '&', ',', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'//', '~', '¬', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x').token_options
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', '(', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '-', '/', '+', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x,').token_options
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '...', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y').token_options
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '/', '+', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y)').token_options
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {',', '(', '@', '∧', '∃', '&'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'//', '¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊤', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y),').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', 'True', '⊤', 'False'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y), C(3, z)').token_options
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', ',', '∧', '&', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '¬', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-~').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '(', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', 'False', '⊥', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-~B(x)').token_options
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'&', ',', '@', '(', '∧', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-', '//'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊤', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-~B(x),').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, ...)').token_options
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {',', '∧', '@', '(', '∃', '&'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '//', '-', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', '⊤', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y), C(3, z), (').token_options
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y), C(3, z), (z').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(),
-                'Operators': {'-', '==', '<=', '+', '!=', '>=', '>', '<', '/', '*', '**'}, 'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'<=', '==', '>=', '**', '>', '+', '/', '<', '-', '*', '!='}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x, y), C(3, z), (z ==').token_options
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'...', '@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x + 5 *').token_options
-    expected = {'Signs': {'(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x / 2').token_options
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '**', '*', '-', '+'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(f(x').token_options
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', '(', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '/', '**', '+'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x + (-5),').token_options
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'...', '@', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x + (-5), "a"').token_options
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'+', '/', '*', '-', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x):-B(x - 5 * 2, @').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
@@ -214,23 +214,23 @@ def test_interactive_aggregation():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('A(x, f(').token_options
-    expected = {'Signs': {'...', '@', ')', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {')', '@', '(', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x, f(y').token_options
-    expected = {'Signs': {',', ')', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '/', '**', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ',', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'**', '-', '/', '+', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x, f(y)').token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '/', '**', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '+', '-', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('A(x, f(y))').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'←', ':=', ':-', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'::', ':=', ':-', '←'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
 
@@ -244,28 +244,28 @@ def test_interactive_uri():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete(f'`{str(label.name)}`').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', ':='}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'+', '**', '*', '/', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete(f'`{str(label.name)}`(x)').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', '←', ':=', ':-'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':-', '←', '::', ':='}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete(f'`{str(label.name)}`(x):-').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊥', 'True', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete(f'`{str(label.name)}`(x):-`{str(regional_part.name)}`').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete(f'`{str(label.name)}`(x):-`{str(regional_part.name)}`(x, y)').token_options
-    expected = {'Signs': {'(', '&', ',', '@', '∧', '∃'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {',', '∃', '&', '(', '∧', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '//', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
@@ -273,70 +273,70 @@ def test_interactive_probabilistic_fact():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('p::').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('p::A').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('p::A(').token_options
-    expected = {'Signs': {')', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = completer.complete('p::A(3').token_options
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('p::A(3)').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', 'True', '⊤', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('0.8::A("a b",').token_options
-    expected = {'Signs': {'@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+                'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = completer.complete('0.8::A("a b", 3').token_options
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': set(),
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('0.8::A("a b", 3)').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x) :: exp(-d / 5.0)').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': {'-', '/', '*', '+', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':-', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'**', '-', '/', '+', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':-', '←'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x) :: exp(-d / 5.0) :-').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', 'False', '⊤', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x) :: exp(-d / 5.0) :- A(x, d)').token_options
-    expected = {'Signs': {'@', '&', '(', '∃', '∧', ','}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'//', '~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∧', '&', ',', '∃', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬', '//'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete(
         'B(x) :: exp(-d / 5.0) :- A(x, d) &').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '(', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', '⊤', 'False', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete(
         'B(x) :: exp(-d / 5.0) :- A(x, d) & (d < 0.8)').token_options
-    expected = {'Signs': {'@', '&', '(', '∃', '∧', ','}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∧', '&', ',', '(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'EXISTS', 'exists'}}, 'Boleans': {'values': {'True', '⊤', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
@@ -344,28 +344,28 @@ def test_interactive_condition():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('C(x) :- A(x) //').token_options
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- A(x) // B(x)').token_options
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '¬', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊥', 'True', '⊤'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- A(x) // (A(x),').token_options
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', 'False', 'True', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- A(x) // (A(x), B(x))').token_options
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '¬', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '-', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'⊥', '⊤', 'False', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- (A(x), B(x)) // B(x)').token_options
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '¬', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊥', 'True', 'False', '⊤'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
@@ -373,65 +373,65 @@ def test_interactive_existential():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('C(x) :- B(x), exists').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), exists(').token_options
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '...', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), exists(s1').token_options
-    expected = {'Signs': {'(', ',', ';'}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '*', '/', '-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': {'st'}, 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ';', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '+', '-', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'st'}}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), exists(s1;').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), exists(s1; A(s1))').token_options
-    expected = {'Signs': {',', '@', '&', '∧', '∃', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {',', '@', '&', '∃', '(', '∧'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), ∃').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), ∃(').token_options
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'...', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), ∃(s1').token_options
-    expected = {'Signs': {'(', ',', ';'}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '*', '/', '-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': {'st'}, 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {';', ',', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '**', '/', '+'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'st'}}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), ∃(s1 st').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', 'True', 'False', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('C(x) :- B(x), ∃(s1 st A(s1))').token_options
-    expected = {'Signs': {',', '@', '&', '∧', '∃', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {',', '&', '@', '∧', '(', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊤', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete(
         'C(x) :- B(x), exists(s1, s2; A(s1),').token_options
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '(', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊥', 'False', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete(
         'C(x) :- B(x), exists(s1, s2; A(s1), A(s2))').token_options
-    expected = {'Signs': {',', '@', '&', '∧', '∃', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', ',', '@', '&', '∧', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'True', '⊥', '⊤', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     with pytest.raises(UnexpectedTokenError):
@@ -442,23 +442,23 @@ def test_interactive_query():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('ans(').token_options
-    expected = {'Signs': {'...', ')', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {')', '(', '@', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('ans(x)').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':-', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'←', ':-'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('ans(x) :-').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'False', 'True', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', 'True', '⊤', 'False'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('ans(x) :- B(x, y), C(3, y)').token_options
-    expected = {'Signs': {'∧', '@', '∃', ',', '(', '&'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'⊥', 'False', 'True', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', ',', '@', '∧', '∃', '&'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'⊤', '⊥', 'False', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
@@ -466,23 +466,23 @@ def test_interactive_prob_implicit():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('B(x, PROB').token_options
-    expected = {'Signs': {'(', ')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': {'+', '-', '*', '**', '/'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '-', '+', '*', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB,').token_options
-    expected = {'Signs': {'(', '@', '...'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB, y)').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'←', ':-', ':=', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'←', ':-', ':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB, y) :- C(x, y)').token_options
-    expected = {'Signs': {'@', '(', '∃', '&', ',', '∧'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-', '~', '¬', '//'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists', 'ans'}, 'Boleans': {'True', '⊥', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {',', '(', '∃', '@', '&', '∧'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '¬', '~', '//'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'ans', 'exists'}}, 'Boleans': {'values': {'⊤', 'True', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
@@ -490,38 +490,38 @@ def test_interactive_prob_explicit():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('B(x, PROB').token_options
-    expected = {'Signs': {',', '(', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'+', '*', '-', '/', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', '(', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '/', '+', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB(').token_options
-    expected = {'Signs': {'(', '...', ')', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '...', ')', '@'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB(x,').token_options
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'...', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB(x, y)').token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'+', '*', '-', '/', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '/', '+', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB(x, y),').token_options
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB(x, y), y)').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', ':=', ':-', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'←', ':=', ':-', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('B(x, PROB(x, y), y) :- C(x, y)').token_options
-    expected = {'Signs': {'&', '∃', '@', ',', '∧', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬', '//'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists', 'ans'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'&', '@', ',', '∧', '(', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '//', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'ans', 'exists'}}, 'Boleans': {'values': {'⊥', '⊤', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
@@ -529,33 +529,33 @@ def test_interactive_lambda_definition():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('c').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '-', '/', '*'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':=', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'**', '-', '+', '/', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c :=').token_options
-    expected = {'Signs': {'@', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := lambda').token_options
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '(', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := lambda x').token_options
-    expected = {'Signs': {',', '(', ':'}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '-', '/', '*'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ',', ':'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '*', '+', '**', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := lambda x:').token_options
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '...', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := lambda x: x + 1').token_options
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'**', '~', '+', '¬', '-', '/', '*'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'False', '⊥', 'True'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'**', '¬', '~', '*', '+', '/', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
@@ -563,13 +563,13 @@ def test_interactive_lambda_definition_statement():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('c(x, y) := x +').token_options
-    expected = {'Signs': {'@', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c(x, y) := x + y').token_options
-    expected = {'Signs': {'∃', '@', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'**', '+', '¬', '-', '~', '/', '*'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', '⊥', '⊤', 'True'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '/', '¬', '*', '+', '**', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊤', '⊥', 'False', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
@@ -577,33 +577,33 @@ def test_interactive_lambda_application():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('c := (lambda').token_options
-    expected = {'Signs': {'...', '@', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := (lambda x').token_options
-    expected = {'Signs': {',', '(', ':'}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '**', '/', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ':', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '+', '/', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := (lambda x:').token_options
-    expected = {'Signs': {'...', '@', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'...', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := (lambda x: x').token_options
-    expected = {'Signs': {'(', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '**', '/', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '-', '+', '**', '/'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := (lambda x: x + 1)').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('c := (lambda x: x + 1)(2)').token_options
-    expected = {'Signs': {'∃', '@', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '*', '**', '/', '¬', '+'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists', 'ans'}, 'Boleans': {'True', 'False', '⊤', '⊥'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '+', '*', '/', '**', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
@@ -611,54 +611,54 @@ def test_interactive_command_syntax():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('.').token_options
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>'}, 'commands': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>'}}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv').token_options
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv(').token_options
-    expected = {'Signs': {')', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>', '<quoted string>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<string>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv()').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'True', 'False', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', '⊥', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv(A,').token_options
-    expected = {'Signs': {'(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>', '<quoted string>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>', '<string>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete(
         '.load_csv(A, "http://myweb/file.csv", B)').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'True', 'False', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊥', '⊤', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv(sep').token_options
-    expected = {'Signs': {',', ')', '(', '='}, 'Numbers': set(), 'Text': set(), 'Operators': {'*', '**', '/', '+', '-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', '(', '=', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '+', '/', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv(sep=').token_options
-    expected = {'Signs': {'(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>', '<quoted string>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>', '<string>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv(sep=","').token_options
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = completer.complete('.load_csv(sep=",")').token_options
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'},
-                'Boleans': {'True', 'False', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
@@ -666,6 +666,7 @@ def test_interactive_constraint():
     completer = LarkCompleter(COMPILED_GRAMMAR)
 
     res = completer.complete('(x == y)').token_options
-    expected = {'Signs': {',', '&', '∧'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'→', '-:'}, 'Python string': set(), 'Strings': set()}
+    print(res)
+    expected = {'Signs': {'values': {'∧', '&', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'→', '-:'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected

--- a/neurolang/utils/tests/test_interactive_parsing_with_parser.py
+++ b/neurolang/utils/tests/test_interactive_parsing_with_parser.py
@@ -7,222 +7,222 @@ from ...frontend.datalog.standard_syntax import parser
 
 def test_interactive_empty_input():
     res = parser('', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-', '~', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊤', 'True', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_facts():
     res = parser('A', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':=', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '+', '*', '**', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(', interactive=True)
-    expected = {'Signs': {'...', '@', ')', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '...', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A()', interactive=True)
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'←', '.', ':=', ':-', '::'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊥', 'True', 'False', '⊤'}}, 'Expression symbols': {'values': {'←', '::', '.', ':=', ':-'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(3', interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'+', '**', '-', '/', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(3)', interactive=True)
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '¬', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊥', 'False', 'True', '⊤'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A("x"', interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '+', '**', '-', '/'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A("x")', interactive=True)
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊤', 'True', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A("x",', interactive=True)
-    expected = {'Signs': {'@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+                'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = parser("A('x', 3", interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser("A('x', 3,", interactive=True)
-    expected = {'Signs': {'@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+                'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = parser("A('x', 3)", interactive=True)
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'¬', '-', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'True', '⊥', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('''
     `http://uri#test-fact`("x")
     A("x", 3
     ''', interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_rules():
     res = parser('A(x', interactive=True)
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ',', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '/', '**', '+', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x)', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', ':-', ':=', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':-', '::', '←', ':='}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'True', 'False', '⊤', '⊥'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(', interactive=True)
-    expected = {'Signs': {')', '...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {')', '(', '@', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B()', interactive=True)
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'∧', '∃', '(', '&', ',', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'//', '~', '¬', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x', interactive=True)
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', '(', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '-', '/', '+', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x,', interactive=True)
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '...', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y', interactive=True)
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '/', '+', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y)', interactive=True)
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {',', '(', '@', '∧', '∃', '&'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'//', '¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊤', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y),', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', 'True', '⊤', 'False'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y), C(3, z)', interactive=True)
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', ',', '∧', '&', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '¬', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-~', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '(', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', 'False', '⊥', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-~B(x)', interactive=True)
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'&', ',', '@', '(', '∧', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-', '//'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊤', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-~B(x),', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, ...)', interactive=True)
-    expected = {'Signs': {',', '∧', '(', '∃', '&', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {',', '∧', '@', '(', '∃', '&'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '//', '-', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', '⊤', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y), C(3, z), (', interactive=True)
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y), C(3, z), (z', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(),
-                'Operators': {'-', '==', '<=', '+', '!=', '>=', '>', '<', '/', '*', '**'}, 'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'<=', '==', '>=', '**', '>', '+', '/', '<', '-', '*', '!='}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x, y), C(3, z), (z ==', interactive=True)
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'...', '@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x + 5 *', interactive=True)
-    expected = {'Signs': {'(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x / 2', interactive=True)
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '**', '*', '-', '+'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(f(x', interactive=True)
-    expected = {'Signs': {')', ',', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', '(', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '/', '**', '+'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x + (-5),', interactive=True)
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'...', '@', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x + (-5), "a"', interactive=True)
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '+', '/', '*', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'+', '/', '*', '-', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x):-B(x - 5 * 2, @', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_aggregation():
     res = parser('A(x, f(', interactive=True)
-    expected = {'Signs': {'...', '@', ')', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {')', '@', '(', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('A(x, f(y', interactive=True)
-    expected = {'Signs': {',', ')', '('}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '/', '**', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ',', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'**', '-', '/', '+', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x, f(y)', interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '/', '**', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '+', '-', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('A(x, f(y))', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'←', ':=', ':-', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'::', ':=', ':-', '←'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
 
@@ -233,405 +233,408 @@ def test_interactive_uri():
     regional_part = Symbol(
         name='http://sig.biostr.washington.edu/fma3.0#regional_part_of'
     )
-
     res = parser(f'`{str(label.name)}`', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': {'/', '+', '*', '-', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', ':='}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'+', '**', '*', '/', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser(f'`{str(label.name)}`(x)', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', '←', ':=', ':-'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':-', '←', '::', ':='}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser(f'`{str(label.name)}`(x):-', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊥', 'True', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser(f'`{str(label.name)}`(x):-`{str(regional_part.name)}`', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser(f'`{str(label.name)}`(x):-`{str(regional_part.name)}`(x, y)', interactive=True)
-    expected = {'Signs': {'(', '&', ',', '@', '∧', '∃'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'//', '¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'EXISTS', 'exists'}, 'Boleans': {'False', 'True', '⊤', '⊥'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {',', '∃', '&', '(', '∧', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '//', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_probabilistic_fact():
     res = parser('p::', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('p::A', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('p::A(', interactive=True)
-    expected = {'Signs': {')', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = parser('p::A(3', interactive=True)
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('p::A(3)', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', 'True', '⊤', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('0.8::A("a b",', interactive=True)
-    expected = {'Signs': {'@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>'}}
+    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+                'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
     res = parser('0.8::A("a b", 3', interactive=True)
-    expected = {'Signs': {')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': set(),
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('0.8::A("a b", 3)', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('B(x) :: exp(-d / 5.0)', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': {'-', '/', '*', '+', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':-', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'**', '-', '/', '+', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':-', '←'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('B(x) :: exp(-d / 5.0) :-', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', 'False', '⊤', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('B(x) :: exp(-d / 5.0) :- A(x, d)', interactive=True)
-    expected = {'Signs': {'@', '&', '(', '∃', '∧', ','}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'//', '~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∧', '&', ',', '∃', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬', '//'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
-    res = parser('B(x) :: exp(-d / 5.0) :- A(x, d) &', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    res = parser(
+        'B(x) :: exp(-d / 5.0) :- A(x, d) &', interactive=True)
+    expected = {'Signs': {'values': {'∃', '(', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', '⊤', 'False', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
-    res = parser('B(x) :: exp(-d / 5.0) :- A(x, d) & (d < 0.8)',
-                 interactive=True)
-    expected = {'Signs': {'@', '&', '(', '∃', '∧', ','}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊥', '⊤', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    res = parser(
+        'B(x) :: exp(-d / 5.0) :- A(x, d) & (d < 0.8)', interactive=True)
+    expected = {'Signs': {'values': {'∧', '&', ',', '(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'EXISTS', 'exists'}}, 'Boleans': {'values': {'True', '⊤', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_condition():
     res = parser('C(x) :- A(x) //', interactive=True)
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- A(x) // B(x)', interactive=True)
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '¬', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'False', '⊥', 'True', '⊤'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- A(x) // (A(x),', interactive=True)
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊥', 'False', 'True', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- A(x) // (A(x), B(x))', interactive=True)
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '¬', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'~', '-', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'⊥', '⊤', 'False', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- (A(x), B(x)) // B(x)', interactive=True)
-    expected = {'Signs': {'(', '∃', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '¬', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'ans', 'EXISTS'}, 'Boleans': {'⊤', '⊥', 'True', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊥', 'True', 'False', '⊤'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_existential():
     res = parser('C(x) :- B(x), exists', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), exists(', interactive=True)
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '...', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), exists(s1', interactive=True)
-    expected = {'Signs': {'(', ',', ';'}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '*', '/', '-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': {'st'}, 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ';', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '+', '-', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'st'}}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), exists(s1;', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), exists(s1; A(s1))', interactive=True)
-    expected = {'Signs': {',', '@', '&', '∧', '∃', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {',', '@', '&', '∃', '(', '∧'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊤', 'False', '⊥', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), ∃', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), ∃(', interactive=True)
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'...', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), ∃(s1', interactive=True)
-    expected = {'Signs': {'(', ',', ';'}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '*', '/', '-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': {'st'}, 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {';', ',', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '**', '/', '+'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'st'}}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), ∃(s1 st', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'~', '¬'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', 'True', 'False', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('C(x) :- B(x), ∃(s1 st A(s1))', interactive=True)
-    expected = {'Signs': {',', '@', '&', '∧', '∃', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {',', '&', '@', '∧', '(', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊤', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
-    res = parser('C(x) :- B(x), exists(s1, s2; A(s1),', interactive=True)
-    expected = {'Signs': {'(', '@', '∃'}, 'Numbers': set(), 'Text': set(), 'Operators': {'¬', '~'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    res = parser(
+        'C(x) :- B(x), exists(s1, s2; A(s1),', interactive=True)
+    expected = {'Signs': {'values': {'∃', '(', '@'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'True', '⊥', 'False', '⊤'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
-    res = parser('C(x) :- B(x), exists(s1, s2; A(s1), A(s2))',
-                 interactive=True)
-    expected = {'Signs': {',', '@', '&', '∧', '∃', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'¬', '~', '-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', 'True', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    res = parser(
+        'C(x) :- B(x), exists(s1, s2; A(s1), A(s2))', interactive=True)
+    expected = {'Signs': {'values': {'(', ',', '@', '&', '∧', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'True', '⊥', '⊤', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     with pytest.raises(UnexpectedTokenError):
-        res = parser('C(x) :- B(x), exists(s1; )', interactive=True)
+        parser('C(x) :- B(x), exists(s1; )', interactive=True)
 
 
 def test_interactive_query():
     res = parser('ans(', interactive=True)
-    expected = {'Signs': {'...', ')', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {')', '(', '@', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('ans(x)', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':-', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'←', ':-'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('ans(x) :-', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': set(), 'Text': set(), 'Operators': {'~', '¬'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS'}, 'Boleans': {'⊥', 'False', 'True', '⊤'}, 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'¬', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊥', 'True', '⊤', 'False'}}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('ans(x) :- B(x, y), C(3, y)', interactive=True)
-    expected = {'Signs': {'∧', '@', '∃', ',', '(', '&'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'⊥', 'False', 'True', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', ',', '@', '∧', '∃', '&'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'⊤', '⊥', 'False', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_prob_implicit():
     res = parser('B(x, PROB', interactive=True)
-    expected = {'Signs': {'(', ')', ','}, 'Numbers': set(), 'Text': set(), 'Operators': {'+', '-', '*', '**', '/'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')', '('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '-', '+', '*', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB,', interactive=True)
-    expected = {'Signs': {'(', '@', '...'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB, y)', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'←', ':-', ':=', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'←', ':-', ':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB, y) :- C(x, y)', interactive=True)
-    expected = {'Signs': {'@', '(', '∃', '&', ',', '∧'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'-', '~', '¬', '//'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists', 'ans'}, 'Boleans': {'True', '⊥', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {',', '(', '∃', '@', '&', '∧'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '¬', '~', '//'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'ans', 'exists'}}, 'Boleans': {'values': {'⊤', 'True', '⊥', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_prob_explicit():
     res = parser('B(x, PROB', interactive=True)
-    expected = {'Signs': {',', '(', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'+', '*', '-', '/', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', '(', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '*', '/', '+', '**'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB(', interactive=True)
-    expected = {'Signs': {'(', '...', ')', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'(', '...', ')', '@'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB(x,', interactive=True)
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'...', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB(x, y)', interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'+', '*', '-', '/', '**'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '/', '+', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB(x, y),', interactive=True)
-    expected = {'Signs': {'(', '...', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'commands': set(), 'functions': set(), 'base symbols': set(), 'query symbols': set()}
+    expected = {'Signs': {'values': {'@', '(', '...'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB(x, y), y)', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'::', ':=', ':-', '←'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'←', ':=', ':-', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('B(x, PROB(x, y), y) :- C(x, y)', interactive=True)
-    expected = {'Signs': {'&', '∃', '@', ',', '∧', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '¬', '//'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists', 'ans'}, 'Boleans': {'⊥', 'True', '⊤', 'False'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<command identifier>', '<identifier regular expression>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'&', '@', ',', '∧', '(', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '//', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'ans', 'exists'}}, 'Boleans': {'values': {'⊥', '⊤', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_lambda_definition():
     res = parser('c', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '-', '/', '*'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {':=', '::'}, 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'**', '-', '+', '/', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {':=', '::'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('c :=', interactive=True)
-    expected = {'Signs': {'@', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('c := lambda', interactive=True)
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '(', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('c := lambda x', interactive=True)
-    expected = {'Signs': {',', '(', ':'}, 'Numbers': set(), 'Text': set(), 'Operators': {'**', '+', '-', '/', '*'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ',', ':'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'/', '*', '+', '**', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('c := lambda x:', interactive=True)
-    expected = {'Signs': {'...', '(', '@'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '...', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('c := lambda x: x + 1', interactive=True)
-    expected = {'Signs': {'@', '(', '∃'}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'**', '~', '+', '¬', '-', '/', '*'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'ans', 'exists'}, 'Boleans': {'⊤', 'False', '⊥', 'True'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<command identifier>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'**', '¬', '~', '*', '+', '/', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<identifier_regexp>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_lambda_definition_statement():
     res = parser('c(x, y) := x +', interactive=True)
-    expected = {'Signs': {'@', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('c(x, y) := x + y', interactive=True)
-    expected = {'Signs': {'∃', '@', '('}, 'Numbers': {'<integer>', '<float>'}, 'Text': set(),
-                'Operators': {'**', '+', '¬', '-', '~', '/', '*'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'ans', 'exists', 'EXISTS'}, 'Boleans': {'False', '⊥', '⊤', 'True'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<identifier regular expression>', '<text>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '∃', '('}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-', '/', '¬', '*', '+', '**', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'⊤', '⊥', 'False', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_lambda_application():
     res = parser('c := (lambda', interactive=True)
-    expected = {'Signs': {'...', '@', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '...'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<text>', '<cmd_identifier>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('c := (lambda x', interactive=True)
-    expected = {'Signs': {',', '(', ':'}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '**', '/', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ':', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '+', '/', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('c := (lambda x:', interactive=True)
-    expected = {'Signs': {'...', '@', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'...', '(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('c := (lambda x: x', interactive=True)
-    expected = {'Signs': {'(', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': {'-', '*', '**', '/', '+'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'(', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'*', '-', '+', '**', '/'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('c := (lambda x: x + 1)', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('c := (lambda x: x + 1)(2)', interactive=True)
-    expected = {'Signs': {'∃', '@', '('}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'~', '-', '*', '**', '/', '¬', '+'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'EXISTS', 'exists', 'ans'}, 'Boleans': {'True', 'False', '⊤', '⊥'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<command identifier>', '<identifier regular expression>', '<text>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', '∃'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '+', '*', '/', '**', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'EXISTS', 'exists', 'ans'}}, 'Boleans': {'values': {'False', '⊥', '⊤', 'True'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>', '<text>', '<identifier_regexp>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_command_syntax():
     res = parser('.', interactive=True)
-    expected = {'Signs': set(), 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<command identifier>'}, 'commands': set()}
+    expected = {'Signs': {'values': set()}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<cmd_identifier>'}}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv', interactive=True)
-    expected = {'Signs': {'('}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {'('}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv(', interactive=True)
-    expected = {'Signs': {')', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>', '<quoted string>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<string>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv()', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'True', 'False', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '(', '∃'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '~', '-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'ans', 'exists', 'EXISTS'}}, 'Boleans': {'values': {'⊤', '⊥', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv(A,', interactive=True)
-    expected = {'Signs': {'(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>', '<quoted string>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>', '<string>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
-    res = parser('.load_csv(A, "http://myweb/file.csv", B)', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(),
-                'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'}, 'Boleans': {'True', 'False', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    res = parser(
+        '.load_csv(A, "http://myweb/file.csv", B)', interactive=True)
+    expected = {'Signs': {'values': {'∃', '@', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'EXISTS', 'ans'}}, 'Boleans': {'values': {'⊥', '⊤', 'True', 'False'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<identifier_regexp>', '<cmd_identifier>', '<text>'}}, 'commands': {'values': set()}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv(sep', interactive=True)
-    expected = {'Signs': {',', ')', '(', '='}, 'Numbers': set(), 'Text': set(), 'Operators': {'*', '**', '/', '+', '-'},
-                'Cmd_identifier': set(), 'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {')', '(', '=', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': {'-', '+', '/', '**', '*'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv(sep=', interactive=True)
-    expected = {'Signs': {'(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-'},
-                'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>', '<quoted string>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'@', '('}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<identifier_regexp>', '<cmd_identifier>', '<string>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv(sep=","', interactive=True)
-    expected = {'Signs': {',', ')'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': set(), 'Python string': set(), 'Strings': set()}
+    expected = {'Signs': {'values': {',', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 
     res = parser('.load_csv(sep=",")', interactive=True)
-    expected = {'Signs': {'∃', '(', '@'}, 'Numbers': {'<float>', '<integer>'}, 'Text': set(), 'Operators': {'-', '¬', '~'}, 'Cmd_identifier': set(), 'Functions': {'lambda'}, 'Identifier_regexp': set(), 'Reserved words': {'exists', 'EXISTS', 'ans'},
-                'Boleans': {'True', 'False', '⊥', '⊤'}, 'Expression symbols': {'.'}, 'Python string': set(), 'Strings': {'<text>', '<identifier regular expression>', '<command identifier>'}, 'functions': set(), 'base symbols': set(), 'query symbols': set(), 'commands': set()}
+    expected = {'Signs': {'values': {'(', '∃', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}},
+                'Text': {'values': set()}, 'Operators': {'values': {'¬', '-', '~'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': {'lambda'}}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': {'exists', 'ans', 'EXISTS'}}, 'Boleans': {'values': {'⊤', 'True', 'False', '⊥'}}, 'Expression symbols': {'values': {'.'}}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>', '<cmd_identifier>', '<identifier_regexp>'}}, 'functions': {'values': set()}, 'base symbols': {'values': set()}, 'query symbols': {'values': set()}, 'commands': {'values': set()}}
     assert res == expected
 
 
 def test_interactive_constraint():
-    res = parser("(x == y)", interactive=True)
-    expected = {'Signs': {',', '&', '∧'}, 'Numbers': set(), 'Text': set(), 'Operators': set(), 'Cmd_identifier': set(),
-                'Functions': set(), 'Identifier_regexp': set(), 'Reserved words': set(), 'Boleans': set(), 'Expression symbols': {'→', '-:'}, 'Python string': set(), 'Strings': set()}
+    res = parser('(x == y)', interactive=True)
+    print(res)
+    expected = {'Signs': {'values': {'∧', '&', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+                'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'→', '-:'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected

--- a/neurolang/utils/tests/test_interactive_parsing_with_parser.py
+++ b/neurolang/utils/tests/test_interactive_parsing_with_parser.py
@@ -634,7 +634,6 @@ def test_interactive_command_syntax():
 
 def test_interactive_constraint():
     res = parser('(x == y)', interactive=True)
-    print(res)
     expected = {'Signs': {'values': {'∧', '&', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
                 'Operators': {'values': set()}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': {'→', '-:'}}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected


### PR DESCRIPTION
--- Summary --------------------------------------------------------------------

A] Implemented the method involved in a query resolution and its pytest test
   -> Modified files :

      'neurolang/frontend/query_resolution_datalog.py'
      'neurolang/frontend/tests/test_frontend.py'

--- Details --------------------------------------------------------------------

1/ File neurolang/frontend/query_resolution_datalog.py

Additions :

- compute_datalog_program_for_autocompletion() method

Modifications :

- Minor modifications to be consistent with PEP8 convention

2/ File neurolang/frontend/tests/test_frontend.py

Additions :

- test_neurolang_dl_datalog_code_statement_autocompletion() function