### PR TITLE
feat: query-restricted grounding for CP-Logic probabilistic resolution

### DIFF
--- a/neurolang/probabilistic/cplogic/gm_provenance_solver.py
+++ b/neurolang/probabilistic/cplogic/gm_provenance_solver.py
@@ -97,8 +97,9 @@ def solve_succ_query(query_predicate, cpl_program):
     n.d., 30.
 
     """
-    return problog_solve_succ_query(query_predicate, cpl_program)
-    grounded = ground_cplogic_program(cpl_program)
+    from .grounding import get_grounding_predicate, ground_cplogic_program, ground_cplogic_program_for_query
+    # return problog_solve_succ_query(query_predicate, cpl_program)
+    grounded = ground_cplogic_program_for_query(cpl_program, query_predicate)
     translator = CPLogicGroundingToGraphicalModelTranslator()
     gm = translator.walk(grounded)
     qpred_symb = query_predicate.functor

--- a/neurolang/probabilistic/cplogic/grounding.py
+++ b/neurolang/probabilistic/cplogic/grounding.py
@@ -12,6 +12,7 @@ from ...expressions import Constant, ExpressionBlock, Symbol
 from ...logic import Implication
 from ...logic.expression_processing import (
     TranslateToLogic,
+    extract_logic_atoms,
     extract_logic_predicates,
 )
 from ...relational_algebra import (
@@ -59,6 +60,60 @@ def cplogic_to_datalog(cpl_program):
                 )
             dl.add_extensional_predicate_from_tuples(pred_symb, relation.value)
     return dl
+
+
+def cplogic_to_datalog_for_query(cpl_program, query_reachable_predicates):
+    """
+    Convert a CP-Logic program to a Datalog program restricted
+    to predicates transitively reachable from a query.
+
+    Parameters
+    ----------
+    cpl_program : CPLogicProgram
+        The full CP-Logic program.
+    query_reachable_predicates : set of Symbol
+        Predicate symbols that are transitively reachable
+        from the query (including the query predicate itself).
+
+    Returns
+    -------
+    Datalog
+        Restricted Datalog program containing only rules and
+        extensional facts needed to answer the query.
+    """
+    dl = Datalog()
+    for pred_symb in cpl_program.predicate_symbols:
+        if pred_symb not in query_reachable_predicates:
+            continue
+        if pred_symb in cpl_program.intensional_database():
+            if len(cpl_program.symbol_table[pred_symb].formulas) > 1:
+                raise ForbiddenDisjunctionError(
+                    "CP-Logic programs do not support disjunctions"
+                )
+            for formula in cpl_program.symbol_table[pred_symb].formulas:
+                dl.walk(formula)
+        else:
+            if pred_symb in cpl_program.extensional_database():
+                relation = cpl_program.symbol_table[pred_symb]
+            else:
+                relation = remove_probability_column(
+                    cpl_program.symbol_table[pred_symb]
+                )
+            dl.add_extensional_predicate_from_tuples(pred_symb, relation.value)
+    return dl
+
+
+def _get_reachable_predicates_from_query(cpl_program, query_predicate):
+    from ...datalog.expression_processing import reachable_code
+    query_rule = Implication(query_predicate, Constant[bool](True))
+    reachable_code_union = reachable_code(query_rule, cpl_program)
+    reachable_preds = {query_predicate.functor}
+    for rule in reachable_code_union.formulas:
+        reachable_preds.add(rule.consequent.functor)
+        for pred in extract_logic_atoms(rule.antecedent):
+            if isinstance(pred.functor, Symbol):
+                reachable_preds.add(pred.functor)
+    return reachable_preds
 
 
 def build_extensional_grounding(pred_symb, tuple_set):
@@ -119,9 +174,14 @@ def build_pfact_grounding_from_set(pred_symb, relation):
     return build_probabilistic_grounding(pred_symb, relation, Grounding)
 
 
-def build_grounding(cpl_program, dl_instance):
+def build_grounding(cpl_program, dl_instance, restricted_predicates=None):
     groundings = []
-    for pred_symb in cpl_program.predicate_symbols:
+    pred_iter = (
+        cpl_program.predicate_symbols
+        if restricted_predicates is None
+        else restricted_predicates
+    )
+    for pred_symb in pred_iter:
         relation = cpl_program.symbol_table[pred_symb]
         if pred_symb in cpl_program.pfact_pred_symbs:
             groundings.append(
@@ -149,6 +209,52 @@ def ground_cplogic_program(cpl_program):
     chase = Chase(dl_program)
     dl_instance = chase.build_chase_solution()
     return build_grounding(cpl_program, dl_instance)
+
+
+def ground_cplogic_program_for_query(cpl_program, query_predicate):
+    """
+    Ground only the subset of a CP-Logic program transitively
+    reachable from a query predicate.
+
+    This avoids the cost of grounding the entire program when only
+    a small fraction of its predicates are needed to answer a query.
+
+    Parameters
+    ----------
+    cpl_program : CPLogicProgram
+        The CP-Logic program to ground.
+    query_predicate : FunctionApplication
+        The query predicate (e.g. ``P(x, y)``) whose transitive
+        dependencies determine which rules/facts to ground.
+
+    Returns
+    -------
+    ExpressionBlock
+        Grounding expressions restricted to predicates reachable
+        from ``query_predicate``.
+    """
+    reachable_preds = _get_reachable_predicates_from_query(
+        cpl_program, query_predicate
+    )
+    # Ensure extensional / probabilistic predicates that are directly
+    # referenced (but never occur as rule consequents) are still included.
+    for pred in reachable_preds.copy():
+        if pred in cpl_program.extensional_database():
+            continue
+        if pred in cpl_program.pfact_pred_symbs or \
+           pred in cpl_program.pchoice_pred_symbs:
+            continue
+        relation = cpl_program.symbol_table.get(pred)
+        if relation is None:
+            continue
+        for atom in extract_logic_atoms(relation):
+            if isinstance(atom.functor, Symbol):
+                reachable_preds.add(atom.functor)
+
+    dl_program = cplogic_to_datalog_for_query(cpl_program, reachable_preds)
+    chase = Chase(dl_program)
+    dl_instance = chase.build_chase_solution()
+    return build_grounding(cpl_program, dl_instance, restricted_predicates=reachable_preds)
 
 
 def get_grounding_predicate(grounded_exp):

--- a/neurolang/probabilistic/cplogic/problog_solver.py
+++ b/neurolang/probabilistic/cplogic/problog_solver.py
@@ -88,16 +88,41 @@ def add_rule_to_problog(rule, pl):
     pl += pl_rule
 
 
-def cplogic_to_problog(cpl):
+def cplogic_to_problog(cpl, query_pred=None):
+    """
+    Convert a CP-Logic program to a ProbLog program.
+
+    Parameters
+    ----------
+    cpl : CPLogicProgram
+        The CP-Logic program to convert.
+    query_pred : FunctionApplication, optional
+        If provided, only predicates transitively reachable from the
+        query predicate are included in the ProbLog program.
+    """
+    from .grounding import _get_reachable_predicates_from_query
+    if query_pred is not None:
+        reachable = _get_reachable_predicates_from_query(cpl, query_pred)
+    else:
+        reachable = None
+
     pl = problog.program.SimpleProgram()
     for pred_symb, relation in cpl.extensional_database().items():
+        if reachable is not None and pred_symb not in reachable:
+            continue
         add_facts_to_problog(pred_symb, relation, pl)
     for pred_symb in cpl.pfact_pred_symbs:
+        if reachable is not None and pred_symb not in reachable:
+            continue
         add_probfacts_to_problog(pred_symb, cpl.symbol_table[pred_symb], pl)
     for pred_symb in cpl.pchoice_pred_symbs:
+        if reachable is not None and pred_symb not in reachable:
+            continue
         add_probchoice_to_problog(pred_symb, cpl.symbol_table[pred_symb], pl)
     for union in cpl.intensional_database().values():
         for rule in union.formulas:
+            if reachable is not None and rule.consequent.functor not in reachable:
+                continue
             if is_within_language_prob_query(rule):
                 rule = within_language_succ_query_to_intensional_rule(rule)
             add_rule_to_problog(rule, pl)
@@ -129,7 +154,7 @@ def pl_solution_to_nl_solution(pl_solution, query_preds):
 
 
 def solve_succ_query(query_pred, cpl):
-    pl = cplogic_to_problog(cpl)
+    pl = cplogic_to_problog(cpl, query_pred=query_pred)
     query = problog.logic.Term("query")
     pl += query(nl_pred_to_pl_pred(query_pred))
     res = problog.core.ProbLog.convert(pl, problog.sdd_formula.SDD).evaluate()

--- a/neurolang/probabilistic/cplogic/tests/test_grounding.py
+++ b/neurolang/probabilistic/cplogic/tests/test_grounding.py
@@ -14,18 +14,20 @@ from ...expressions import (
     ProbabilisticChoiceGrounding,
     ProbabilisticFact,
 )
-from ..grounding import ground_cplogic_program
+from ..grounding import ground_cplogic_program, ground_cplogic_program_for_query
 from ..program import CPLogicProgram
 
 P = Symbol("P")
 Q = Symbol("Q")
 R = Symbol("R")
 Z = Symbol("Z")
+W = Symbol("W")
 x = Symbol("x")
 y = Symbol("y")
 p = Symbol("p")
 a = Constant("a")
 b = Constant("b")
+c = Constant("c")
 
 
 def test_cplogic_grounding():
@@ -129,3 +131,37 @@ def test_forbidden_disjunction():
     cpl.walk(code)
     with pytest.raises(ForbiddenDisjunctionError):
         ground_cplogic_program(cpl)
+
+
+def test_ground_cplogic_program_for_query_restricts_to_reachable():
+    """Grounding with a query predicate should skip unreachable predicates."""
+    cpl_program = CPLogicProgram()
+    cpl_program.add_probabilistic_facts_from_tuples(
+        Q, {(1.0, "a"), (0.5, "b")}
+    )
+    cpl_program.add_probabilistic_facts_from_tuples(
+        P, {(0.8, "a"), (0.2, "c")}
+    )
+    rule = Implication(Z(x), Conjunction((Q(x),)))
+    unreachable_rule = Implication(W(x), Conjunction((P(x), Q(x))))
+    code = Union((rule, unreachable_rule))
+    cpl_program.walk(code)
+
+    full_grounded = ground_cplogic_program(cpl_program)
+    full_predicates = {
+        grounding.expression.consequent.functor
+        for grounding in full_grounded.expressions
+    }
+    assert W in full_predicates
+    assert P in full_predicates
+
+    restricted_grounded = ground_cplogic_program_for_query(cpl_program, Z(x))
+    restricted_predicates = {
+        grounding.expression.consequent.functor
+        for grounding in restricted_grounded.expressions
+    }
+
+    assert Z in restricted_predicates
+    assert Q in restricted_predicates
+    assert W not in restricted_predicates
+    assert P not in restricted_predicates


### PR DESCRIPTION
Adds  to avoid grounding the entire
program when only a query-reachable subset is needed.

Changes:
- : add , , and
- : pass  through to optionally restrict the ProbLog translation
- : switch  to call instead of full grounding
- : add