### PR TITLE
fix(docs): deploy to master branch of neurolang.github.io + add PyPI publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           deploy_key: ${{ secrets.NEUROLANG_GITHUB_IO_DEPLOY_KEY }}
           external_repository: neurolang/neurolang.github.io
-          publish_branch: develop
+          publish_branch: master
           publish_dir: ./doc/_build/html
           force_orphan: true


### PR DESCRIPTION
Two changes:

**1. Docs deploy fix** — The GitHub Pages site for neurolang.github.io is configured to serve from its `master` branch, but the docs workflow was pushing built documentation to the `develop` branch. This meant the site was showing stale content from March 2024 — despite successful CI runs every time something was pushed to master. Changed `publish_branch: develop` to `publish_branch: master`.

**2. PyPI publish workflow** — Added `.github/workflows/publish.yml` that builds the package with hatchling and publishes to PyPI when a version tag is pushed. Also creates a GitHub Release with auto-generated notes. Requires a `PYPI_TOKEN` secret to be set in the repository.