### PR TITLE
ci: add PyPI publish workflow triggered by version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "[0-9]*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install build hatchling hatch-vcs
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the package with hatchling and publishes to PyPI when a version tag (matching `[0-9]*`) is pushed. Also creates a GitHub Release with auto-generated notes.

The `PYPI_TOKEN` secret is already configured in the repository.

After this is merged, pushing a tag like `0.1a21` will automatically build and publish to PyPI.