### PR TITLE
fix: incidental bugfixes and cosmetic docstring changes

### DIFF
--- a/neurolang/datalog/exceptions.py
+++ b/neurolang/datalog/exceptions.py
@@ -20,7 +20,7 @@ class BoundAggregationApplicationError(InvalidMagicSetError):
     Magic Sets algorithm does not work if an argument which is an aggregate
     function is bound.
 
-    Example
+    Examples
     -------
     Q(x, count(y)) :- P(x, y)
     ans(x) :- Q(x, 3)

--- a/neurolang/frontend/query_resolution.py
+++ b/neurolang/frontend/query_resolution.py
@@ -93,8 +93,8 @@ class QueryBuilderBase:
         ValueError
             if no symbol could be found with given name
 
-        Example
-        -------
+        Examples
+        --------
         >>> p_ir = DatalogProgram()
         >>> nl = QueryBuilderBase(program_ir=p_ir)
         >>> nl.add_symbol(3, "x")
@@ -251,12 +251,12 @@ class QueryBuilderBase:
         when exiting the environment context
 
         Yields
-        -------
+        ------
         QuerySymbolsProxy
             in dynamic mode, can be used to create symbols on-the-fly
 
-        Example
-        -------
+        Examples
+        --------
         >>> p_ir = DatalogProgram()
         >>> nl = QueryBuilderBase(program_ir=p_ir)
         >>> with nl.environment as e:
@@ -283,12 +283,12 @@ class QueryBuilderBase:
         when exiting the scope context
 
         Yields
-        -------
+        ------
         QuerySymbolsProxy
             in dynamic mode, can be used to create symbols on-the-fly
 
-        Example
-        -------
+        Examples
+        --------
         >>> p_ir = DatalogProgram()
         >>> nl = QueryBuilderBase(program_ir=p_ir)
         >>> with nl.scope as e:
@@ -345,8 +345,8 @@ class QueryBuilderBase:
         List[str]
             list of symbols of type leq Callable
 
-        Example
-        -------
+        Examples
+        --------
         >>> p_ir = DatalogProgram()
         >>> nl = QueryBuilderBase(program_ir=p_ir)
         >>> def f(x: int) -> int:
@@ -390,8 +390,8 @@ class QueryBuilderBase:
         fe.Symbol
             created symbol
 
-        Example
-        -------
+        Examples
+        --------
         >>> p_ir = DatalogProgram()
         >>> nl = QueryBuilderBase(program_ir=p_ir)
         >>> @nl.add_symbol
@@ -451,8 +451,8 @@ class QueryBuilderBase:
         ValueError
             if no symbol could be found with given name
 
-        Example
-        -------
+        Examples
+        --------
         >>> p_ir = DatalogProgram()
         >>> nl = QueryBuilderBase(program_ir=p_ir)
         >>> nl.add_symbol(3, "x")

--- a/neurolang/frontend/query_resolution_expressions.py
+++ b/neurolang/frontend/query_resolution_expressions.py
@@ -58,7 +58,7 @@ class Expression(object):
         Expression
             FrontEnd expression
 
-        Example
+        Examples
         -------
         >>> nl = NeurolangDL()
         >>> from neurolang import expressions as ir
@@ -91,7 +91,7 @@ class Expression(object):
         Operation
             FunctionApplication of self to *args
 
-        Example
+        Examples
         -------
         >>> nl = NeurolangDL()
         >>> A = nl.new_symbol(name="A")
@@ -139,7 +139,7 @@ class Expression(object):
         and an Expression value. self[key] will be
         interpreted as self(*key) (see __call__ method)
 
-        Warning
+        Warnings
         -------
         If logic programming is not enabled by the builder,
         will set item in the general Python sense !
@@ -152,7 +152,7 @@ class Expression(object):
             If not a frontend expression, will be cast as
             one with a Constant value
 
-        Example
+        Examples
         -------
         >>> nl = NeurolangDL()
         >>> A = nl.new_symbol(name="A")
@@ -181,7 +181,7 @@ class Expression(object):
             a- self(*key) if key is a tuple
             b- self(key) if not
 
-        Warning
+        Warnings
         -------
         If logic programming is not enabled by the builder,
         will get item in the general Python sense !
@@ -196,7 +196,7 @@ class Expression(object):
         Union["Expression", Any]
             see description
 
-        Example
+        Examples
         -------
         >>> nl = NeurolangDL()
         >>> A = nl.new_symbol(name="A")
@@ -223,7 +223,7 @@ class Expression(object):
         str
             representation of expression
 
-        Example
+        Examples
         -------
         >>> nl = NeurolangDL()
         >>> A = nl.new_symbol(name="nameA")
@@ -398,7 +398,7 @@ class Operation(Expression):
     An Operation is an Expression representing the
     application of an operator to a tuple of arguments
 
-    Example
+    Examples
     -------
     >>> nl = NeurolangDL()
     >>> A = nl.new_symbol(name="A")
@@ -482,7 +482,7 @@ class Symbol(Expression):
     A Symbol represents an atomic Expression. Its is
     the most recurrent element of queries
 
-    Example
+    Examples
     -------
     >>> nl = NeurolangDL()
     >>> A = nl.new_symbol(name="nameA")

--- a/neurolang/relational_algebra/relational_algebra.py
+++ b/neurolang/relational_algebra/relational_algebra.py
@@ -498,16 +498,17 @@ class FunctionApplicationListMember(Definition):
     Notes
     -----
     In the case of an extended projection operation, as described in [1]_,
-    a function application list member can either be
-        - a single attribute (column) name in the relation, resulting in a
-          normal non-extended projection,
-        - an expression `x -> y` where `x` and `y` are both attribute (column)
-          names, `x` effectively being rename as `y`,
-        - or an expression `E -> z` where `E` is an expression involving
-          attributes of the relation, arithmetic operators, and string
-          operators, and `z` is a new name for the attribute that results from
-          the calculation implied by `E`. For example, `a + b -> x` represents
-          the sum of the attributes `a` and `b`, renamed `x`.
+    a function application list member can either be:
+
+    - a single attribute (column) name in the relation, resulting in a
+      normal non-extended projection,
+    - an expression `x -> y` where `x` and `y` are both attribute (column)
+      names, `x` effectively being rename as `y`,
+    - or an expression `E -> z` where `E` is an expression involving
+      attributes of the relation, arithmetic operators, and string
+      operators, and `z` is a new name for the attribute that results from
+      the calculation implied by `E`. For example, `a + b -> x` represents
+      the sum of the attributes `a` and `b`, renamed `x`.
 
     .. [1] Garcia-Molina, Hector, Jeffrey D. Ullman, and Jennifer Widom.
        "Database systems: the complete book." (2009).

--- a/neurolang/relational_algebra_provenance.py
+++ b/neurolang/relational_algebra_provenance.py
@@ -564,7 +564,7 @@ class ProvenanceExtendedProjectionMixin(PatternWalker):
     sets for which the semantics are not modified.
 
     An extended projection on a provenance set is allowed if all the
-    non-provenance columns `c` are projected _as is_ (i.e. `c -> c`), which
+    non-provenance columns `c` are projected as-is (i.e. `c -> c`), which
     ensures the number of tuples is going to be exactly the same in the
     resulting provenance set, and the provenance label is still going to be
     semantically valid. This is useful in particular for projecting a constant

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -286,8 +286,9 @@ class RelationalAlgebraFrozenSet(abc.RelationalAlgebraFrozenSet):
         Examples
         --------
         Select the elements where col0 == col1 and col1 == col2
+
         >>> ras = RelationalAlgebraFrozenSet(
-                [(i % 2, i, i * 2) for i in range(5)])
+        ...     [(i % 2, i, i * 2) for i in range(5)])
         >>> ras.selection_columns({0:1, 1: 2})
            0  1  2
         0  0  0  0


### PR DESCRIPTION
## Summary

Minor bugfixes and cosmetic docstring changes found while working on the SQUALL feature branch, split into its own PR to keep `demianw:squall-cnl` focused on SQUALL changes.

### Bugfixes
- `examples/plot_load_destrieux_datalog_ir.py`: Fix missing `enumerate()`
- `examples/plot_load_destrieux_left_hemisphere_gyri.py`: Fix missing `enumerate()`

### Cosmetic docstring fixes
- `neurolang/datalog/exceptions.py`: "Example" → "Examples"
- `neurolang/frontend/query_resolution.py`: "Example" → "Examples"
- `neurolang/frontend/query_resolution_expressions.py`: "Example" → "Examples"
- `neurolang/relational_algebra/relational_algebra.py`: Add colons in bullet list
- `neurolang/relational_algebra_provenance.py`: "as is" → "as-is"
- `neurolang/utils/relational_algebra_set/pandas.py": Fix docstring indent

8 files changed, 41 insertions(+), 39 deletions(-)