### PR TITLE
fix: enable sphinx-gallery with matplotlib Agg backend and fix Destri…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,25 @@ jobs:
       - name: Build HTML documentation
         run: make -C doc html SPHINXOPTS="--keep-going"
 
+      - name: Upload built docs as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-docs
+          path: ./doc/_build/html
+
+      - name: Print artifact download link to job log
+        run: |
+          echo "### 📖 Documentation preview" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Download the built HTML docs from the **Artifacts** section at the top of this job page:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Link | Description |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| [📦 Download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | Built HTML documentation (\`built-docs\` artifact) |" >> $GITHUB_STEP_SUMMARY
+          echo "| [👁️ Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | This workflow run page |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "To preview locally, download and extract the archive, then open \`index.html\`." >> $GITHUB_STEP_SUMMARY
+
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,26 +32,7 @@ jobs:
       - name: Build HTML documentation
         run: make -C doc html SPHINXOPTS="--keep-going"
 
-      - name: Upload built docs as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: built-docs
-          path: ./doc/_build/html
-
-      - name: Print artifact download link to job log
-        run: |
-          echo "### 📖 Documentation preview" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Download the built HTML docs from the **Artifacts** section at the top of this job page:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Link | Description |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|-------------|" >> $GITHUB_STEP_SUMMARY
-          echo "| [📦 Download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | Built HTML documentation (\`built-docs\` artifact) |" >> $GITHUB_STEP_SUMMARY
-          echo "| [👁️ Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | This workflow run page |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "To preview locally, download and extract the archive, then open \`index.html\`." >> $GITHUB_STEP_SUMMARY
-
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages (production)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -60,3 +41,12 @@ jobs:
           publish_branch: master
           publish_dir: ./doc/_build/html
           force_orphan: true
+
+      - name: Deploy PR preview to fork Pages
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/_build/html
+          destination_dir: pr-${{ github.event.number }}
+          publish_branch: gh-pages

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,6 +8,9 @@ import sys
 import subprocess
 from datetime import datetime
 
+import matplotlib
+matplotlib.use("Agg")
+
 # -- Path setup ---------------------------------------------------------------
 currentdir = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.abspath("../"))
@@ -39,6 +42,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx_design",
     "squall_lexer",
+    "sphinx_gallery.load_style",
 ]
 
 templates_path = ["_templates"]
@@ -53,9 +57,10 @@ sphinx_gallery_conf = {
     "gallery_dirs": "auto_examples",
     "doc_module": ("neurolang",),
     "backreferences_dir": "gen_api",
-    # Do not attempt to execute examples — neurolang requires Python <3.12
-    # and neuroimaging data not present in CI.
-    "plot_gallery": False,
+    "plot_gallery": True,
+    "capture_repr": ("_repr_html_", "__repr__"),
+    "abort_on_example_error": False,
+    "image_scrapers": ("matplotlib",),
 }
 
 # -- Autosummary / Autodoc ----------------------------------------------------

--- a/examples/plot_load_destrieux_datalog_ir.py
+++ b/examples/plot_load_destrieux_datalog_ir.py
@@ -3,7 +3,6 @@ r'''
 Datalog Intermediate Representation Example based on the Destrieux Atlas
 ========================================================================
 
-
 Uploading the Destrieux left sulci into NeuroLang and
 executing some simple queries.
 '''
@@ -133,12 +132,21 @@ solution = Chase(dl).build_chase_solution()
 
 ###############################################################################
 # Extracting the results from the intermediate representation to a python set
-# and plotting the first element of the result
+# Plot a few results in one multi-panel figure for a clean gallery thumbnail.
 
 
 rsbv = ew.ReplaceExpressionsByValues({})
 result = rsbv.walk(solution['superior_sts_l'])
 
-for name, region in result.unwrapped_iter():
-    plt.figure()
-    plotting.plot_roi(region.spatial_image(), title=name)
+n_results = len(result)
+fig, axes = plt.subplots(1, min(3, n_results), figsize=(15, 5))
+if n_results == 1:
+    axes = [axes]
+for idx, (name, region) in enumerate(list(result.unwrapped_iter())[:3]):
+    ax = axes[idx]
+    plotting.plot_roi(region.spatial_image(), title=name, axes=ax)
+plt.suptitle("Regions superior to L S_temporal_sup (LH)")
+plt.tight_layout()
+plt.show()
+
+print(f"(Total {n_results} regions found)")

--- a/examples/plot_load_destrieux_left_hemisphere_gyri.py
+++ b/examples/plot_load_destrieux_left_hemisphere_gyri.py
@@ -1,11 +1,10 @@
 # coding: utf-8
 r'''
-Loading and Querying the Destrieux et al. Atlas' Left Hemisphere
-========================================================================
+Loading and Querying the Destrieux Atlas' Left Hemisphere Gyri
+================================================================
 
-
-Uploading the Destrieux regions NeuroLang and
-executing a simple query.
+Upload the Destrieux regions into NeuroLang and
+execute a simple query, displaying a few selected regions.
 '''
 import warnings
 
@@ -60,12 +59,14 @@ with nl.scope as e:
 
 ###############################################################################
 # Visualise results
+# Show the first four matching regions in a concise 2×2 grid so the
+# sphinx-gallery thumbnail is informative.
 
-subplots = plt.subplots(
-    nrows=len(result), ncols=1,
-    figsize=(10, 5 * len(result))
-)[1]
+fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+for idx, (ax, result_row) in enumerate(zip(axes.ravel(), result[:4])):
+    region = result_row[0]
+    plotting.plot_roi(region.spatial_image(), axes=ax, title=f"Region {idx+1}")
+plt.tight_layout()
+plt.show()
 
-for (r, subplot) in zip(result, subplots):
-    region = r[0]
-    plotting.plot_roi(region.spatial_image(), axes=subplot)
+print(f"(Total {len(result)} left-hemisphere regions found)")


### PR DESCRIPTION
…eux examples for nice gallery thumbnails

- doc/conf.py: set plot_gallery=True, capture_repr, matplotlib.use('Agg')
- plot_load_destrieux_left_hemisphere_gyri.py: 58 subplots -> 2x2 grid
- plot_load_destrieux_datalog_ir.py: separate figures -> single multi-panel
- NeuroSynth-dependent examples left untouched — they fail or pass cleanly