### PR TITLE
feat: contains/Destroy Datalog operator with tuple literal grammar

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -44,6 +44,17 @@ Intermediate Language Representations
    relational_algebra_provenance 
 
 
+Command-line Interface & Engine Registry
+-----------------------------------------
+
+.. autosummary::
+   :toctree: gen_api
+
+   neurolang.utils.cli
+   neurolang.utils.engine_registry
+   neurolang.utils.engines.base
+
+
 Indices and tables
 ------------------
 * :ref:`genindex`

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,7 +12,56 @@ format below, then move it to the appropriate version section when releasing.
 Unreleased
 ----------
 
-*No unreleased changes yet.*
+**New features:**
+
+* Declarative engine registry for the ``neurolang-query`` CLI.
+  Engines are defined in YAML and initialised by pluggable Python modules
+  under :file:`neurolang/utils/engines/`.  Includes ``--list-engines`` for
+  discovery and ``--list-predicates`` showing declarative metadata without
+  data download.  (:mod:`neurolang.utils.engine_registry`,
+  :mod:`neurolang.utils.engines`)
+
+* The existing NeuroSynth and Destrieux engines were refactored into the
+  new declarative system.  Engine init code moved from
+  :mod:`neurolang.utils.cli` to :mod:`neurolang.utils.engines.neurosynth.init`
+  and :mod:`neurolang.utils.engines.destrieux.init`.
+
+* ``neurolang-query --list-predicates`` no longer requires downloading data;
+  predicate metadata is read from the YAML engine config.
+
+* **Datalog init** — engines can declare inline Datalog rules that run after
+  the Python init via the ``datalog_init`` YAML field.  Derived predicates can
+  be defined without writing Python.
+
+* **CSV/TSV relations** — engines can load tabular data files as extensional
+  predicates with the ``relations`` YAML field.  Supported formats:
+  ``.csv``, ``.tsv``, ``.csv.gz``, ``.tsv.gz``.
+  Relation entries may include an optional ``description`` field for
+  predicate metadata shown by ``--list-predicates``.  The ``file`` value
+  may be a URL for automatic download.
+
+* **Builtins** — engines can declare ``builtins: [exp, log, startswith]``
+  in YAML to register known functions as callable symbols without Python.
+
+* **Downloads** — the ``downloads`` section fetches files from URLs
+  (with optional archive extraction) before other init phases.
+
+* **Probabilistic choices** — engines can declare uniform probabilistic
+  choices declaratively with ``probabilistic_choice:`` instead of calling
+  ``add_uniform_probabilistic_choice_over_set`` in Python.
+
+* **Ontology loading** — the ``ontologies`` section loads OWL/RDF
+  ontologies from URLs or local paths.
+
+* **Atlases** — engines can declare ``atlases:`` with nilearn atlas names
+  (``destrieux``, ``schaefer``, ``difumo``) and parameters.  Atlas regions
+  are loaded as ``ExplicitVBR`` predicates before Datalog init rules.
+
+* **Declarative migration** — ``exp``, ``log``, ``startswith`` symbols
+  now come from YAML ``builtins`` rather than ``base.py``; the
+  ``selected_study`` choice for the neurosynth engine is now declared
+  in the engine YAML instead of Python init code; the ``destrieux``
+  predicate is now declared in the YAML ``atlases:`` section.
 
 
 v0.0.1 (Alpha)

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -86,6 +86,201 @@ such as :meth:`add_tuple_set` and :meth:`add_atlas_set` to load these
 data sources.
 
 
+Declarative Engine Registry & CLI
+----------------------------------
+
+NeuroLang ships a command-line interface, ``neurolang-query``, that provides
+a quick way to run Datalog queries against pre-configured datasets without
+writing Python:
+
+.. code-block:: bash
+
+   # List available dataset engines
+   neurolang-query --list-engines
+
+   # List predicates for the NeuroSynth engine
+   neurolang-query --engine neurosynth --list-predicates
+
+   # Run a Datalog query
+   neurolang-query "ans(t) :- term_in_study_tfidf(t, w, s)"
+
+   # Use the Destrieux atlas engine
+   neurolang-query --engine destrieux "ans(name) :- destrieux(name, region)"
+
+Engines are declared declaratively in :file:`engines/engines.yaml`:
+
+.. code-block:: yaml
+
+   engines:
+     neurosynth:
+       description: "Neurosynth database — forward and reverse inference"
+       requires_mni_mask: true
+       python_init: "neurolang.utils.engines.neurosynth.init"
+       datalog_init: |
+         study_with_peaks(S) :- peak_reported(I, J, K, S)
+       relations:
+         extra_data: "shared/my_data.csv"
+       predicates:
+         peak_reported:
+           arity: 4
+           columns: [i, j, k, study_id]
+           description: "Reported activation peaks in voxel coordinates"
+         ...
+
+Each engine references a Python module that exports
+``init_engine(nl, mask, data_dir)``.  The :mod:`neurolang.utils.engine_registry`
+module handles YAML loading, MNI mask retrieval, and delegating to the
+engine's init script.
+
+**Init phases.**  When :func:`~neurolang.utils.engine_registry.build_engine`
+builds an engine, it runs up to eight phases in order:
+
+#. **Builtins** (``builtins``) — registers known functions (``exp``,
+   ``log``, ``startswith``) as callable symbols.  Simple list in YAML::
+
+       builtins: [exp, log, startswith]
+
+#. **Python init** (``python_init``) — imports the module and calls
+   ``init_engine(nl, mask, data_dir)``.  Use this for downloading data,
+   registering complex symbols, or loading neuroimaging atlases.
+
+#. **Downloads** (``downloads``) — fetches files from URLs before the
+   other phases.  Supports archive extraction::
+
+       downloads:
+         - url: "https://example.com/data.tar.gz"
+           dest: my_engine/
+           extract: true
+
+#. **Templates** (``templates``) — downloads neuroimaging templates via
+   **nilearn** or **TemplateFlow** (if the ``templateflow`` package is
+   installed).  Each template can optionally register a
+   ``voxel(i, j, k)`` predicate from its non-zero mask::
+
+       templates:
+         # Nilearn brain mask → voxel(i, j, k) predicate
+         mni_brain:
+           source: nilearn
+           variant: brain_mask
+           predicate: voxel
+         # Nilearn T1 template (2 mm) — just download, no predicate
+         mni_t1:
+           source: nilearn
+           variant: template
+           resolution: 2
+         # TemplateFlow T1 template at 1 mm
+         t1_highres:
+           source: templateflow
+           template: MNI152NLin2009cAsym
+           resolution: 1
+           suffix: T1w
+
+   Supported **nilearn** variants:
+
+   * ``brain_mask`` — MNI152 brain mask (``load_mni152_brain_mask``)
+   * ``gm_mask`` — grey-matter mask (``load_mni152_gm_mask``)
+   * ``wm_mask`` — white-matter mask (``load_mni152_wm_mask``)
+   * ``template`` — MNI152 T1 template (``load_mni152_template``;
+     pass ``resolution: 1`` or ``resolution: 2``)
+   * ``gm_template`` — grey-matter template
+   * ``wm_template`` — white-matter template
+
+   **TemplateFlow** templates require ``pip install templateflow`` and
+   are identified by a ``template`` name from the
+   `TemplateFlow repository <https://www.templateflow.org/>`_
+   (e.g. ``MNI152NLin2009cAsym``, ``MNIInfant``).  The ``suffix``
+   and ``resolution`` fields select the specific image variant.
+
+   When ``predicate`` is set, the template is loaded as a NIfTI image
+   and all non-zero voxels are registered as a
+   ``predicate(i, j, k)`` tuple set — useful as a coordinate-space
+   reference in Datalog queries.
+
+#. **Atlases** (``atlases``) — downloads brain atlases via nilearn and
+   registers each region as a predicate with
+   :class:`~neurolang.regions.ExplicitVBR` geometry::
+
+       atlases:
+         destrieux:
+           predicate_name: destrieux
+         schaefer:
+           n_rois: 400
+           yeo_networks: 7
+           resolution_mm: 2
+           predicate_name: schaefer_400
+         difumo:
+           dimension: 64
+           threshold: 0.5
+           predicate_name: difumo_64
+
+   For probabilistic atlases (``difumo``) a second predicate is registered
+   automatically — ``{name}_prob(component, i, j, k, prob)`` — with the raw
+   probability value at each voxel for each component (filtered by
+   ``prob_threshold``, default 0.01)::
+
+       atlases:
+         difumo:
+           dimension: 64
+           threshold: 0.5
+           prob_threshold: 0.01
+           predicate_name: difumo_64
+           prob_predicate_name: difumo_64_prob
+
+   Supported atlases: ``destrieux`` (deterministic), ``schaefer``
+   (deterministic), ``difumo`` (probabilistic).
+
+#. **Datalog init** (``datalog_init``) — an optional YAML multiline string
+   of Datalog rules.  These are evaluated after templates and atlases
+   so they can reference template-derived voxel predicates and atlas
+   predicates::
+
+       datalog_init: |
+         left_region(N, R) :- destrieux(N, R), startswith('lh', N)
+         right_region(N, R) :- destrieux(N, R), startswith('rh', N)
+
+#. **Relations** (``relations``) — loads CSV/TSV files as extensional
+   predicates.  Each entry maps a relation name to a file path relative to
+   the :file:`engines/` directory.  The ``file`` value may be a URL for
+   automatic download::
+
+       relations:
+         my_table: "my_engine/data.csv"
+         extra_refs: "shared/references.tsv"
+
+   For richer metadata that appears in ``--list-predicates`` output, use a
+   dict with an optional ``description`` field::
+
+       relations:
+         my_table:
+           file: "https://example.com/data.csv"
+           description: "Experiment metadata loaded from CSV"
+
+   Supported formats: ``.csv``, ``.tsv``, ``.csv.gz``, ``.tsv.gz``.  The
+   file is read with ``pandas.read_csv`` and registered via
+   :meth:`~neurolang.frontend.query_resolution_datalog.QueryBuilderDatalog.add_tuple_set`.
+   Because relations are loaded after the Datalog init, your derived rules
+   can already reference them.
+
+#. **Probabilistic choices** (``probabilistic_choice``) — declares uniform
+   probabilistic choices over existing predicates::
+
+       probabilistic_choice:
+         selected_study:
+           source: study
+           description: "Uniform choice over studies"
+
+#. **Ontologies** (``ontologies``) — loads OWL/RDF ontologies from URLs
+   or local paths::
+
+       ontologies:
+         - url: "https://example.com/ontology.owl"
+
+All phases are optional — include only what your engine needs.
+
+To add a new engine, create a YAML entry and a corresponding
+:mod:`init` module under :file:`neurolang/utils/engines/`.  See
+:mod:`neurolang.utils.engines.neurosynth.init` for a complete example.
+
 Architecture
 -------------
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -106,6 +106,64 @@ NumPy-style docstrings. Run ``flake8`` before committing:
    flake8 neurolang/
 
 
+Adding a New Dataset Engine
+----------------------------
+
+The ``neurolang-query`` CLI uses a declarative engine registry to manage
+dataset backends.  To add a new engine:
+
+1. Write a YAML entry in ``neurolang/utils/engines/engines.yaml``:
+
+   .. code-block:: yaml
+
+      my_dataset:
+        description: "Short description of the dataset"
+        requires_mni_mask: false
+        python_init: "neurolang.utils.engines.my_dataset.init"
+        datalog_init: |
+          derived_pred(X) :- base_pred(X)
+        relations:
+          base_pred: "my_dataset/base_data.csv"
+        predicates:
+          my_predicate:
+            arity: 2
+            columns: [name, value]
+            description: "What this predicate represents"
+
+   The optional fields ``datalog_init`` (inline Datalog rules) and
+   ``relations`` (CSV/TSV files loaded as predicates) run after the
+   Python init.  See :ref:`concepts` for details.
+
+2. Create the init module at
+   ``neurolang/utils/engines/my_dataset/init.py`` that exports:
+
+   .. code-block:: python
+
+      from pathlib import Path
+      import nibabel as nib
+      from neurolang.frontend import NeurolangPDL
+
+      def init_engine(
+          nl: NeurolangPDL,
+          mask: nib.Nifti1Image | None,
+          data_dir: Path
+      ) -> None:
+          \"\"\"Register symbols and load data into *nl*.\"\"\"
+          # Register predicates with nl.add_tuple_set, etc.
+
+   If your engine needs the common neuroimaging symbols (``exp``, ``log``,
+   ``agg_count``, ``agg_create_region``, etc.), call
+   ``neurolang.utils.engines.base.init_base_engine(nl, mask)``
+   from within ``init_engine``.
+
+3. Add unit tests in ``neurolang/utils/tests/test_cli.py``, specifically
+   in the ``TestEngineRegistry`` class to verify that your engine is
+   discoverable and its config loads correctly.
+
+4. Run ``pytest neurolang/utils/tests/test_cli.py`` to confirm everything
+   passes.
+
+
 Reporting Bugs
 --------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,6 +83,7 @@ a guided walkthrough.
    install
    tutorial
    tutorial_squall
+   tutorial_datalog
    concepts
    auto_examples/index
    api

--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -131,7 +131,9 @@ fact : constant_predicate
 constant_predicate : identifier "(" (literal | ext_identifier) ("," (literal | ext_identifier))* ")"
                    | identifier "(" ")"
 
-?literal : number | text
+?literal : number | text | tuple_literal
+
+tuple_literal : "(" argument ("," argument)+ ")"
 
 ext_identifier : "@" identifier
 identifier : cmd_identifier | identifier_regexp
@@ -526,6 +528,15 @@ class DatalogTransformer(Transformer):
 
     def text(self, ast):
         return Constant((ast[0].replace("'", "")).replace('"', ''))
+
+    def tuple_literal(self, ast):
+        from neurolang.expressions import Constant as ConstantExpr
+        values = tuple(a for a in ast if not isinstance(a, str))
+        result = ConstantExpr(values)
+        for v in values:
+            if isinstance(v, Symbol):
+                result._symbols.add(v)
+        return result
 
     def pos_int(self, ast):
         return Constant(int((ast[0]).value))

--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -21,6 +21,7 @@ from typing import (
 )
 from uuid import uuid1
 
+import numpy as np
 import pandas as pd
 from neurolang.type_system import (
     get_args,
@@ -896,3 +897,97 @@ class NeurolangPDL(QueryBuilderDatalog):
             ra_set.projection_to_unnamed(*projections.keys())
         )
         return fe.Symbol(self, name)
+
+    def k_fold_assign(
+        self,
+        iterable: Iterable[Tuple[Any, ...]],
+        k: int = 10,
+        shuffle: bool = True,
+        seed: Optional[int] = None,
+        name: Optional[str] = None,
+    ) -> Tuple[fe.Symbol, fe.Symbol]:
+        """
+        Generate K-fold cross-validation assignments as a deterministic relation.
+
+        Each item in the iterable is assigned to one of k folds. The method
+        creates two relations:
+        - ``{name}_assign`` with columns ``(item_cols..., fold_id)`` mapping each
+          item to its fold.
+        - ``{name}_fold_id`` with column ``(fold_id,)`` enumerating all fold IDs.
+
+        The intended usage pattern within a Datalog query is:
+
+        .. code-block:: python
+
+            fold_assign, fold_set = nl.k_fold_assign(items, k=10, name="cv")
+
+            with nl.scope as e:
+                # training items per fold via negation over fold assignments
+                e.train_set[e.fold_id, e.item_id] = (
+                    fold_set[e.fold_id] &
+                    all_items[e.item_id] &
+                    ~fold_assign[e.item_id, e.fold_id]
+                )
+
+        The fold dimension becomes just another column in joins.  All standard
+        Datalog operators (negation, aggregation, projection) work across folds
+        without looping.
+
+        Parameters
+        ----------
+        iterable : Iterable[Tuple[Any, ...]]
+            Iterable of tuples to assign to folds.  Each tuple becomes one row
+            in the resulting relation, with an extra ``fold_id`` column appended.
+        k : int, optional
+            Number of folds, by default 10.
+        shuffle : bool, optional
+            Whether to shuffle items before assigning folds, by default True.
+        seed : Optional[int], optional
+            Random seed for reproducible fold assignments, by default None.
+        name : Optional[str], optional
+            Prefix for the output symbol names.  If None, a UUID is generated.
+
+        Returns
+        -------
+        Tuple[fe.Symbol, fe.Symbol]
+            ``(fold_assignment_symbol, fold_id_symbol)``.
+            - ``fold_assignment`` has columns ``(item_columns..., fold_id)``.
+            - ``fold_id_set`` has a single column ``(fold_id,)``.
+        """
+        if name is None:
+            name = str(uuid1())
+
+        if isinstance(iterable, pd.DataFrame):
+            iterable = iterable.rename(
+                columns={n: i for i, n in enumerate(iterable.columns)}
+            )
+
+        items = list(iterable)
+        n = len(items)
+
+        if shuffle:
+            rng = np.random.default_rng(seed)
+            rng.shuffle(items)
+
+        fold_ids_for_items = np.arange(n) % k
+
+        fold_assign_tuples = []
+        for item, fid in zip(items, fold_ids_for_items):
+            if isinstance(item, tuple):
+                item_tuple = item
+            elif isinstance(item, list):
+                item_tuple = tuple(item)
+            else:
+                item_tuple = (item,)
+            fold_assign_tuples.append(item_tuple + (int(fid),))
+
+        fold_id_tuples = [(i,) for i in range(k)]
+
+        assign_sym = self.add_tuple_set(
+            fold_assign_tuples, name=f"{name}_assign"
+        )
+        fold_sym = self.add_tuple_set(
+            fold_id_tuples, name=f"{name}_fold_id"
+        )
+
+        return assign_sym, fold_sym

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -5,6 +5,7 @@ Complements QueryBuilderBase with query capabilities,
 as well as Region and Neurosynth capabilities
 """
 from collections import defaultdict
+import operator
 from neurolang.datalog.magic_sets import magic_rewrite
 from neurolang.exceptions import (
     ForbiddenDisjunctionError, NeuroLangException, UnsupportedProgramError,
@@ -105,6 +106,7 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         )
         self.translate_expression_to_datalog = TranslateToDatalogSemantics()
         self.datalog_parser = datalog_parser
+        self.add_symbol(operator.contains, name="contains")
 
     @property
     def current_program(self) -> List[fe.Expression]:

--- a/neurolang/regions.py
+++ b/neurolang/regions.py
@@ -392,6 +392,13 @@ class ExplicitVBR(VolumetricBrainRegion):
     def __hash__(self):
         return hash((self.voxels.tobytes(), self.affine.tobytes()))
 
+    def __contains__(self, voxel):
+        """Return True if *voxel* is one of this region's voxels."""
+        voxel = np.asanyarray(voxel)
+        if voxel.ndim == 1:
+            return any(np.all(self.voxels == voxel, axis=1))
+        return all(any(np.all(self.voxels == v, axis=1)) for v in voxel)
+
 
 class ExplicitVBROverlay(ExplicitVBR):
     def __init__(

--- a/neurolang/utils/cli.py
+++ b/neurolang/utils/cli.py
@@ -1,0 +1,447 @@
+"""
+Command-line interface for NeuroLang query execution.
+
+Provides a ``neurolang-query`` command that initializes a NeuroLang engine
+from the :ref:`engine registry <neurolang.utils.engine_registry>` and
+executes Datalog queries from arguments, files, or standard input.
+
+Usage
+-----
+::
+
+    # List available engines
+    neurolang-query --list-engines
+
+    # List predicates for an engine
+    neurolang-query --engine neurosynth --list-predicates
+
+    # List RA sets for an engine
+    neurolang-query --engine neurosynth --list-sets
+
+    # Inline query
+    neurolang-query "ans(t) :- term_in_study_tfidf(t, w, s)"
+
+    # Query from file
+    neurolang-query -f query.dl
+
+    # Query from stdin
+    echo "ans(t) :- term_in_study_tfidf(t, f, s)" | neurolang-query
+
+    # Destrieux atlas engine
+    neurolang-query --engine destrieux "ans(name) :- destrieux(name, region)"
+
+    # Squall (controlled English) query
+    neurolang-query --squall "obtain every peak_reported."
+    neurolang-query --squall -f query.squall
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from neurolang import expressions as ir
+from neurolang.datalog.chase import Chase
+from neurolang.datalog.expressions import Implication
+from neurolang.datalog import WrappedRelationalAlgebraSet
+from neurolang.frontend import NeurolangPDL
+from neurolang.utils import engine_registry
+
+
+def _read_query(args) -> str:
+    """Obtain the Datalog program from the CLI arguments."""
+    if args.file:
+        return Path(args.file).read_text(encoding="utf-8")
+    if args.query:
+        return args.query
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    parser = _build_parser()
+    parser.print_help()
+    sys.exit(1)
+
+
+def _rename_unnamed_columns(df, column_names):
+    """Replace auto-generated column names with *column_names* when safe."""
+    if column_names is not None and len(column_names) == len(df.columns):
+        unnamed = all(
+            isinstance(c, int)
+            or (isinstance(c, str) and c.startswith("c"))
+            for c in df.columns
+        )
+        if unnamed:
+            df.columns = column_names
+    return df
+
+
+def _emit(df, fmt):
+    """Format a DataFrame in *fmt* mode (table, csv, or json)."""
+    if df.empty:
+        return "(empty)"
+    if fmt == "csv":
+        return df.to_csv(index=False)
+    if fmt == "json":
+        return df.to_json(orient="records", indent=2)
+    return df.to_string(index=False)
+
+
+def _format_result(
+    result, fmt: str = "table", column_names: Optional[list[str]] = None
+) -> str:
+    """Format a query result for display."""
+    if result is None:
+        return ""
+    if isinstance(result, bool):
+        return "true" if result else "false"
+
+    try:
+        # Unwrap Constant -> concrete set when chase produced wrapped result
+        if hasattr(result, "value") and hasattr(result.value, "unwrap"):
+            inner = result.value.unwrap()
+            if hasattr(inner, "as_pandas_dataframe"):
+                return _emit(
+                    _rename_unnamed_columns(inner.as_pandas_dataframe(), column_names),
+                    fmt,
+                )
+            result = inner
+
+        # Get a DataFrame from the bare set (named or unnamed columns)
+        if hasattr(result, "columns") and len(result.columns) > 0:
+            df = pd.DataFrame(iter(result), columns=result.columns)
+        else:
+            rows = list(iter(result))
+            if not rows:
+                return "(empty)"
+            arity = result.arity if hasattr(result, "arity") else len(rows[0])
+            df = pd.DataFrame(rows, columns=[f"c{i}" for i in range(arity)])
+
+        return _emit(_rename_unnamed_columns(df, column_names), fmt)
+    except Exception as exc:
+        import sys
+
+        print(f"Warning: result formatting failed: {exc}", file=sys.stderr)
+        return str(result)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="neurolang-query",
+        description="Run a Datalog query against a NeuroLang dataset engine.",
+    )
+
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "query",
+        nargs="?",
+        default=None,
+        help="Datalog program string (e.g. 'ans(x) :- P(x)'). "
+        "If omitted and stdin is a pipe, read from stdin.",
+    )
+    source.add_argument(
+        "--file",
+        "-f",
+        metavar="PATH",
+        default=None,
+        help="Read the Datalog program from a file.",
+    )
+
+    parser.add_argument(
+        "--engine",
+        "-e",
+        default="neurosynth",
+        help="Dataset engine to use (default: neurosynth).  "
+        "Use --list-engines to see all available engines.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        "-d",
+        metavar="DIR",
+        default="neurolang_data",
+        help="Directory for cached data downloads (default: neurolang_data).",
+    )
+    parser.add_argument(
+        "--resolution",
+        "-r",
+        type=float,
+        default=None,
+        metavar="MM",
+        help="Isotropic MNI resolution in mm (default: native).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("table", "csv", "json"),
+        default="table",
+        help="Output format (default: table).",
+    )
+    parser.add_argument(
+        "--list-predicates",
+        "-l",
+        action="store_true",
+        help="Instead of running a query, list the available predicates "
+        "for the engine and exit.",
+    )
+    parser.add_argument(
+        "--list-sets",
+        action="store_true",
+        help="Instead of running a query, list the available Relational "
+        "Algebra sets (EDB relations) for the engine and exit.",
+    )
+    parser.add_argument(
+        "--list-engines",
+        action="store_true",
+        help="List available dataset engines and exit.",
+    )
+    parser.add_argument(
+        "--squall",
+        "-s",
+        action="store_true",
+        help="Interpret the input as a SQUALL (controlled English) program "
+        "instead of classical Datalog syntax.  Supports ``define as`` "
+        "rule definitions and ``obtain`` queries.",
+    )
+
+    return parser
+
+
+def _execute_program(nl: NeurolangPDL, program_text: str):
+    """Execute a Datalog program using direct chase evaluation.
+
+    This bypasses :meth:`NeurolangPDL._execute_query` which does not support
+    query bodies that are conjunctions, comparisons, or EDB-only predicates.
+    Instead it converts every ``Query`` into an ``Implication`` rule, adds it
+    to the program's IDB, and runs the deterministic chase — the same strategy
+    used by the base :class:`~neurolang.frontend.QueryBuilderDatalog`.
+
+    Parameters
+    ----------
+    nl :
+        Initialised engine (``NeurolangPDL`` or ``NeurolangDL``).
+    program_text :
+        Datalog program, possibly containing one ``Query`` rule.
+
+    Returns
+    -------
+    ``None``, ``bool``, or a relational algebra set.
+    """
+    from neurolang.frontend.datalog.standard_syntax import (
+        parser as datalog_parser,
+    )
+
+    ir_prog = datalog_parser(program_text)
+
+    formulas = list(ir_prog.formulas)
+    queries = [f for f in formulas if isinstance(f, ir.Query)]
+    others = [f for f in formulas if not isinstance(f, ir.Query)]
+
+    for f in others:
+        nl.program_ir.walk(f)
+
+    if len(queries) == 0:
+        return None
+
+    if len(queries) > 1:
+        raise ValueError("Only a single query per program is supported.")
+
+    q = queries[0]
+
+    # Extract both the head predicate name and the argument variable names
+    # from the parsed query head.  The head is always a FunctionApplication
+    # whose functor is a Symbol (simple) or a Lambda wrapping a Symbol (parser
+    # sugar), and whose args are Symbol nodes whose .name carries the Datalog
+    # variable name.
+    if isinstance(q.head, ir.FunctionApplication):
+        column_names = [a.name for a in q.head.args]
+        functor = (
+            q.head.functor.body
+            if isinstance(q.head.functor, ir.Lambda)
+            else q.head.functor
+        )
+    else:
+        column_names = None
+        functor = q.head
+
+    pred_name = (
+        functor.name if isinstance(functor, ir.Symbol) else str(functor)
+    )
+
+    # Query → Implication so the DatalogProgram walker registers it as IDB
+    rule = Implication(q.head, q.body)
+    nl.program_ir.walk(rule)
+
+    chase = Chase(nl.program_ir)
+    solution = chase.build_chase_solution()
+
+    for sym, val in solution.items():
+        if sym.name == pred_name:
+            return val, column_names
+
+    return None
+
+
+def _execute_squall_program(
+    nl: NeurolangPDL, program_text: str
+):
+    """Execute a SQUALL (controlled English) program.
+
+    Delegates to :meth:`NeurolangPDL.execute_squall_program`, which
+    handles ``define as …`` rules and ``obtain …`` queries.
+
+    Parameters
+    ----------
+    nl :
+        Initialised engine.
+    program_text :
+        SQUALL program text.
+
+    Returns
+    -------
+    None
+        When there are no ``obtain`` queries.
+    NamedRelationalAlgebraFrozenSet
+        When there is exactly one ``obtain`` query.
+    Dict[str, NamedRelationalAlgebraFrozenSet]
+        When there are multiple ``obtain`` queries.
+    """
+    return nl.execute_squall_program(program_text)
+
+
+def _list_predicates(engine_name: str) -> None:
+    """Print predicate metadata from the YAML engine config."""
+    cfg = engine_registry.get_engine_config(engine_name)
+    print(f"\nEngine: {engine_name}")
+    print(f"  {cfg.get('description', '')}")
+    predicates = engine_registry.get_predicates(engine_name)
+    if not predicates:
+        print("\n  (no predicate metadata declared)")
+        return
+    print("\nAvailable predicates:")
+    for pname, info in predicates.items():
+        cols = ", ".join(info.get("columns", []))
+        desc = info.get("description", "")
+        print(f"\n  {pname}({cols})")
+        if desc:
+            print(f"    {desc}")
+
+
+def _list_sets(nl: NeurolangPDL) -> None:
+    """Print the actual Relational Algebra sets registered in the engine.
+
+    Iterates over the engine's symbol table and displays every entry backed
+    by a :class:`~neurolang.datalog.WrappedRelationalAlgebraSet` — i.e.,
+    concrete extensional (EDB) relations loaded from CSV/TSV files or added
+    via the Python API.
+    """
+    print()
+    st = nl.program_ir.symbol_table
+    sets_found = []
+
+    for sym_name, sym_val in st.items():
+        val = getattr(sym_val, "value", sym_val)
+        if not isinstance(val, WrappedRelationalAlgebraSet):
+            continue
+        ra_set = val.unwrap()
+        arity = ra_set.arity
+        columns = list(ra_set.columns)
+        try:
+            size = len(ra_set)
+        except Exception:
+            size = "?"
+        clean_name = getattr(sym_name, "name", str(sym_name))
+        sets_found.append((clean_name, columns, size, arity))
+
+    if not sets_found:
+        print("  (no RA sets registered)")
+        return
+
+    name_w = max(len(s) for s, _, _, _ in sets_found) + 2
+    cols_w = max(len(str(c)) for _, c, _, _ in sets_found) + 2
+    size_w = max(len(str(s)) for _, _, s, _ in sets_found) + 2
+
+    header = (
+        f"  {'Set':<{name_w}}  {'Columns':<{cols_w}}  {'Rows':>{size_w}}  Arity"
+    )
+    print(header)
+    print(f"  {'-' * name_w}  {'-' * cols_w}  {'-' * size_w}  -----")
+    for name, columns, size, arity in sorted(sets_found, key=lambda x: x[0]):
+        cols_str = str(columns)
+        print(
+            f"  {name:<{name_w}}  {cols_str:<{cols_w}}  {str(size):>{size_w}}  {arity}"
+        )
+    print(f"\n  Total RA sets: {len(sets_found)}")
+
+
+def main(argv: Optional[list] = None) -> None:
+    """CLI entry point: parse arguments, build engine, run query."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list_engines:
+        engine_registry.show_engines()
+        return
+
+    if args.engine not in engine_registry.list_engine_names():
+        available = ", ".join(engine_registry.list_engine_names())
+        print(
+            f"Error: unknown engine {args.engine!r}. "
+            f"Available engines: {available}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    nl = engine_registry.build_engine(
+        args.engine, Path(args.data_dir), args.resolution
+    )
+
+    if args.list_predicates:
+        _list_predicates(args.engine)
+        return
+
+    if args.list_sets:
+        _list_sets(nl)
+        return
+
+    program = _read_query(args)
+    if not program or not program.strip():
+        print("Error: no query provided.", file=sys.stderr)
+        sys.exit(1)
+
+    t0 = time.perf_counter()
+
+    if args.squall:
+        result = _execute_squall_program(nl, program)
+        if isinstance(result, dict):
+            for key, sub_result in result.items():
+                output = _format_result(
+                    sub_result, fmt=args.format, column_names=None
+                )
+                if output:
+                    print(f"── {key} ──")
+                    print(output)
+                    print()
+        else:
+            output = _format_result(
+                result, fmt=args.format, column_names=None
+            )
+            if output:
+                print(output)
+    else:
+        result = _execute_program(nl, program)
+        if isinstance(result, tuple):
+            result, column_names = result
+        else:
+            column_names = None
+        output = _format_result(
+            result, fmt=args.format, column_names=column_names
+        )
+        if output:
+            print(output)
+
+    elapsed = time.perf_counter() - t0
+    print(f"Query completed in {elapsed:.2f} s", file=sys.stderr, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/neurolang/utils/engine_registry.py
+++ b/neurolang/utils/engine_registry.py
@@ -1,0 +1,843 @@
+"""Declarative engine registry for the neurolang-query CLI.
+
+Engines are declared in :file:`engines/engines.yaml`.  Each engine may
+define:
+
+* a **Python initialisation script** (``python_init``);
+* optional **Datalog initialisation code** (``datalog_init``) evaluated
+  after the Python script;
+* optional **CSV/TSV relations** (``relations``) loaded as extensional
+  predicates after the Datalog init.  Each relation entry may carry
+  optional ``name`` and ``description`` fields for predicate metadata
+  used by the ``--list-predicates`` command.  The ``file`` value may be
+  a URL (``http://`` / ``https://``) for automatic download;
+* ``downloads`` — files to fetch (with optional archive extraction);
+* ``templates`` — neuroimaging templates (brain masks, anatomical
+  templates) downloaded via **nilearn** or **TemplateFlow** (if the
+  ``templateflow`` package is installed).  Each template may optionally
+  register a ``voxel(i, j, k)`` predicate from its non-zero mask::
+
+      templates:
+        mni_brain:
+          source: nilearn
+          variant: brain_mask
+          predicate: voxel
+        t1_ref:
+          source: templateflow
+          template: MNI152NLin2009cAsym
+          resolution: 1
+
+* ``ontologies`` — OWL/RDF ontologies to load from URLs or local paths;
+* ``builtins`` — list of known function names (``exp``, ``log``,
+  ``startswith``, etc.) to register as callable symbols;
+* ``probabilistic_choice`` — uniform probabilistic choices declared as
+  ``name: {source: other_predicate}``.
+* ``atlases`` — brain atlases downloaded via nilearn (e.g. ``destrieux``,
+  ``schaefer``, ``difumo``) and registered as predicates with
+  :class:`~neurolang.regions.ExplicitVBR` regions.  Deterministic atlases
+  use ``ExplicitVBR.from_spatial_image_label``; probabilistic atlases
+  are thresholded (default 0.5) to create binary region masks.
+
+Usage
+-----
+::
+
+    from pathlib import Path
+    from neurolang.utils.engine_registry import (
+        build_engine,
+        show_engines,
+        list_engine_names,
+        get_engine_config,
+    )
+
+    # Load engine from the built-in YAML
+    nl = build_engine("neurosynth", data_dir=Path("data"))
+
+    # Load engine from a custom YAML file
+    nl = build_engine("my_engine", yaml_path=Path("my_engines.yaml"),
+                      data_dir=Path("data"))
+
+    # Print available engines with descriptions
+    show_engines()
+
+    # List engine names from a custom YAML
+    for name in list_engine_names(yaml_path=Path("my_engines.yaml")):
+        print(name)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from operator import contains
+
+import nibabel as nib
+import numpy as np
+import yaml
+from nilearn import datasets, image
+
+try:
+    from nilearn.datasets.utils import _fetch_files
+except ImportError:
+    from nilearn.datasets._utils import fetch_files as _fetch_files
+
+if TYPE_CHECKING:
+    from neurolang.frontend import NeurolangPDL
+
+_ENGINES_DIR = Path(__file__).parent / "engines"
+_ENGINES_YAML = _ENGINES_DIR / "engines.yaml"
+
+
+def _builtin_startswith(prefix, s):
+    return s.startswith(prefix)
+
+
+_BUILTIN_SYMBOLS: Dict[str, object] = {
+    "exp": np.exp,
+    "log": np.log,
+    "startswith": _builtin_startswith,
+    "contains": contains,
+}
+
+
+def _merge_predicate_metadata(
+    predicates: Dict[str, Dict[str, Any]],
+    name: str,
+    description: str = "",
+    default_desc: str = "",
+) -> None:
+    """Insert or update a predicate entry's description in *predicates*.
+
+    If *name* is not yet in *predicates*, a new ``{"description": ...,
+    "columns": []}`` entry is added.  If it already exists and has no
+    description, *description* (falling back to *default_desc*) is set.
+    """
+    if name not in predicates:
+        predicates[name] = {
+            "description": description or default_desc,
+            "columns": [],
+        }
+    elif description and not predicates[name].get("description"):
+        predicates[name]["description"] = description
+
+
+def _load_yaml_config(yaml_path: Optional[Path] = None) -> dict:
+    """Load engine YAML from *yaml_path* or the built-in engines file."""
+    if yaml_path is not None:
+        with open(yaml_path) as f:
+            return yaml.safe_load(f)
+    with open(_ENGINES_YAML) as f:
+        return yaml.safe_load(f)
+
+
+def _resolve_relation_file(
+    rel_cfg: dict,
+    engine_name: str,
+    data_dir: Path,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    """Return a local path for a relation entry's ``file`` field.
+
+    If the ``file`` value is a URL it is downloaded via nilearn's
+    ``_fetch_files`` (with caching and optional archive extraction)
+    to ``{data_dir}/{engine_name}/``.
+
+    Local paths are resolved relative to *base_dir* (defaults to the
+    built-in ``engines/`` directory).
+    """
+    raw = rel_cfg["file"]
+    extract_member = rel_cfg.get("extract")
+
+    if raw.startswith(("http://", "https://")):
+        dl_dir = str(data_dir / engine_name)
+        name = Path(raw).name
+        opts = {}
+        if extract_member:
+            opts["uncompress"] = True
+            # If extract specifies a member name, use that as the target file
+            if isinstance(extract_member, list):
+                name = extract_member[0]
+            elif extract_member is not True:
+                name = extract_member
+        result = _fetch_files(dl_dir, [(name, raw, opts)], verbose=0)
+        return Path(result[0])
+    else:
+        resolved = (base_dir or _ENGINES_DIR) / raw
+        if extract_member:
+            dl_dir = str(resolved.parent)
+            name = resolved.name
+            opts = {"uncompress": True}
+            result = _fetch_files(dl_dir, [(name, str(resolved), opts)], verbose=0)
+            return Path(result[0])
+        return resolved
+
+
+def list_engine_names(yaml_path: Optional[Path] = None) -> List[str]:
+    """Return the names of all registered engines.
+
+    Parameters
+    ----------
+    yaml_path :
+        Path to an engine YAML file.  Defaults to the built-in
+        ``engines/engines.yaml``.
+    """
+    config = _load_yaml_config(yaml_path)
+    return sorted(config.get("engines", {}).keys())
+
+
+def get_engine_config(
+    name: str, yaml_path: Optional[Path] = None
+) -> Dict[str, Any]:
+    """Return the YAML configuration dict for a single engine.
+
+    Parameters
+    ----------
+    name :
+        Engine name (key in the YAML ``engines`` dict).
+    yaml_path :
+        Path to an engine YAML file.  Defaults to the built-in
+        ``engines/engines.yaml``.
+
+    Raises
+    ------
+    ValueError
+        If *name* is not a registered engine.
+    """
+    config = _load_yaml_config(yaml_path)
+    engines = config.get("engines", {})
+    if name not in engines:
+        available = ", ".join(engines.keys())
+        raise ValueError(
+            f"Unknown engine: {name!r}. Available engines: {available}"
+        )
+    return dict(engines[name])
+
+
+def show_engines(yaml_path: Optional[Path] = None) -> None:
+    """Print a formatted description of all available engines.
+
+    Parameters
+    ----------
+    yaml_path :
+        Path to an engine YAML file.  Defaults to the built-in
+        ``engines/engines.yaml``.
+    """
+    config = _load_yaml_config(yaml_path)
+    engines = config.get("engines", {})
+    print("Available engines:\n")
+    for name in sorted(engines):
+        desc = engines[name].get("description", "").replace("\n", " ").strip()
+        print(f"  {name}")
+        if desc:
+            print(f"      {desc}")
+        print()
+
+
+def get_predicates(
+    name: str, yaml_path: Optional[Path] = None
+) -> Dict[str, Dict[str, Any]]:
+    """Return the predicate metadata dict for an engine from its YAML config.
+
+    Combines the ``predicates`` section with metadata harvested from the
+    ``relations`` section (each relation entry may carry ``name`` and
+    ``description`` fields).
+
+    Parameters
+    ----------
+    name :
+        Engine name.
+    yaml_path :
+        Path to an engine YAML file.  Defaults to the built-in
+        ``engines/engines.yaml``.
+    """
+    cfg = get_engine_config(name, yaml_path)
+    predicates = dict(cfg.get("predicates", {}))
+
+    for rel_key, rel_cfg in cfg.get("relations", {}).items():
+        if isinstance(rel_cfg, str):
+            continue
+        _merge_predicate_metadata(
+            predicates,
+            rel_cfg.get("name", rel_key),
+            rel_cfg.get("description", ""),
+        )
+
+    for ch_name, ch_cfg in cfg.get("probabilistic_choice", {}).items():
+        _merge_predicate_metadata(
+            predicates,
+            ch_name,
+            ch_cfg.get("description", ""),
+        )
+
+    for atl_name, atl_params in cfg.get("atlases", {}).items():
+        pred_name = atl_params.get("predicate_name", atl_name)
+        _merge_predicate_metadata(
+            predicates,
+            pred_name,
+            atl_params.get("description", ""),
+            default_desc=f"{atl_name} atlas regions",
+        )
+        # Probabilistic atlases also register a probability predicate
+        if _ATLAS_REGISTRY.get(atl_name, {}).get("probabilistic"):
+            prob_name = atl_params.get(
+                "prob_predicate_name", f"{pred_name}_prob"
+            )
+            prob_desc = atl_params.get(
+                "prob_description",
+                f"Raw probabilities for {atl_name} atlas components",
+            )
+            _merge_predicate_metadata(predicates, prob_name, prob_desc)
+
+    for tpl_name, tpl_params in cfg.get("templates", {}).items():
+        pred_name = tpl_params.get("predicate")
+        if pred_name:
+            _merge_predicate_metadata(
+                predicates,
+                pred_name,
+                tpl_params.get("description", ""),
+                default_desc=f"Voxels inside the {tpl_name} template mask",
+            )
+
+    return predicates
+
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+
+_NILEARN_TEMPLATES: Dict[str, Dict[str, Any]] = {
+    "brain_mask": {
+        "func": datasets.load_mni152_brain_mask,
+        "kind": "mask",
+    },
+    "gm_mask": {
+        "func": datasets.load_mni152_gm_mask,
+        "kind": "mask",
+    },
+    "wm_mask": {
+        "func": datasets.load_mni152_wm_mask,
+        "kind": "mask",
+    },
+    "template": {
+        "func": datasets.load_mni152_template,
+        "kind": "anatomical",
+    },
+    "gm_template": {
+        "func": datasets.load_mni152_gm_template,
+        "kind": "anatomical",
+    },
+    "wm_template": {
+        "func": datasets.load_mni152_wm_template,
+        "kind": "anatomical",
+    },
+}
+
+
+def _register_template_predicate(nl, img, pred_name):
+    """Register ``pred_name(i, j, k)`` from all non-zero voxels of *img*."""
+    data = np.asanyarray(img.dataobj)
+    mask = data > 0
+    if not mask.any():
+        mask = data > data.min()  # fallback for masks with negative values
+    coords = np.argwhere(mask)
+    nl.add_tuple_set(coords, name=pred_name)
+
+
+def _fetch_nilearn_template(
+    nl, tpl_name: str, params: dict, data_dir: Path
+) -> None:
+    """Download a template via nilearn and optionally register a voxel predicate.
+
+    Parameters
+    ----------
+    nl :
+        Engine instance.
+    tpl_name :
+        YAML key for this template entry.
+    params :
+        Template config with keys:
+
+        * ``variant`` — one of the keys in ``_NILEARN_TEMPLATES``
+        * ``resolution`` — mm resolution (1 or 2, default 2; only for
+          anatomical variants)
+        * ``predicate`` — optional name for a ``(i, j, k)`` voxel set
+          from non-zero mask voxels
+    data_dir :
+        Data cache directory.  Note that nilearn's ``load_mni152_*``
+        functions use their own global cache (``~/nilearn_data``) rather
+        than this path.
+    """
+    variant = params.get("variant", "brain_mask")
+    info = _NILEARN_TEMPLATES.get(variant)
+    if info is None:
+        raise ValueError(
+            f"Unknown nilearn template variant {variant!r}. "
+            f"Available: {', '.join(sorted(_NILEARN_TEMPLATES))}"
+        )
+
+    kwargs: Dict[str, Any] = {}
+    if info["kind"] == "anatomical":
+        kwargs["resolution"] = params.get("resolution", 2)
+    elif variant in ("brain_mask", "gm_mask", "wm_mask"):
+        kwargs["resolution"] = params.get("resolution")
+
+    img = info["func"](**kwargs)
+
+    pred_name = params.get("predicate")
+    if pred_name:
+        _register_template_predicate(nl, img, pred_name)
+
+
+def _fetch_templateflow_template(
+    nl, tpl_name: str, params: dict
+) -> None:
+    """Download a template via TemplateFlow and optionally register a voxel
+    predicate.
+
+    Requires the ``templateflow`` Python package (``pip install templateflow``).
+    """
+    try:
+        from templateflow import api as tflow
+    except ImportError:
+        raise ImportError(
+            "The 'templateflow' source requires the `templateflow` package. "
+            "Install it with: pip install templateflow"
+        )
+
+    tpl_id = params.get("template")
+    if not tpl_id:
+        raise ValueError(
+            f"TemplateFlow entry {tpl_name!r} is missing the required "
+            f"'template' field (e.g. 'MNI152NLin2009cAsym')."
+        )
+
+    resolution = params.get("resolution")
+    suffix = params.get("suffix", "T1w")
+
+    kwargs: Dict[str, Any] = dict(suffix=suffix)
+    if resolution is not None:
+        kwargs["resolution"] = resolution
+
+    # templateflow.api.get() returns a Path to the downloaded file
+    tpl_path = tflow.get(tpl_id, **kwargs)
+    if tpl_path is None:
+        raise FileNotFoundError(
+            f"TemplateFlow template {tpl_id!r} (suffix={suffix}, "
+            f"resolution={resolution}) could not be resolved."
+        )
+
+    pred_name = params.get("predicate")
+    if pred_name:
+        import nibabel as nib
+
+        img = nib.load(str(tpl_path))
+        _register_template_predicate(nl, img, pred_name)
+
+
+def _load_template(
+    nl, tpl_name: str, params: dict, data_dir: Path
+) -> None:
+    """Download a neuroimaging template and optionally register a voxel
+    predicate.
+
+    Dispatches to the backend named by *params['source']* (``nilearn`` or
+    ``templateflow``).
+    """
+    source = params.get("source", "nilearn")
+    if source == "nilearn":
+        _fetch_nilearn_template(nl, tpl_name, params, data_dir)
+    elif source == "templateflow":
+        _fetch_templateflow_template(nl, tpl_name, params)
+    else:
+        raise ValueError(
+            f"Unknown template source {source!r}. "
+            f"Supported: 'nilearn', 'templateflow'."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atlas helpers
+# ---------------------------------------------------------------------------
+
+def _fetch_atlas_destrieux(**kwargs):
+    return datasets.fetch_atlas_destrieux_2009(**kwargs)
+
+
+def _fetch_atlas_schaefer(**kwargs):
+    return datasets.fetch_atlas_schaefer_2018(**kwargs)
+
+
+def _fetch_atlas_difumo(**kwargs):
+    return datasets.fetch_atlas_difumo(**kwargs)
+
+
+# Parameters in the atlas YAML config that must NOT be forwarded to the
+# nilearn fetch_* function — they are consumed locally by the loader.
+_ATLAS_FETCH_SKIP = {
+    "predicate_name",
+    "description",
+    "threshold",
+    "prob_threshold",
+    "prob_predicate_name",
+}
+
+_ATLAS_REGISTRY = {
+    "destrieux": {
+        "fetch": _fetch_atlas_destrieux,
+        "probabilistic": False,
+    },
+    "schaefer": {
+        "fetch": _fetch_atlas_schaefer,
+        "probabilistic": False,
+    },
+    "difumo": {
+        "fetch": _fetch_atlas_difumo,
+        "probabilistic": True,
+    },
+}
+
+
+def _parse_labels(raw_labels):
+    """Yield ``(index, name)`` pairs from a nilearn labels value.
+
+    Handles the three formats returned by different nilearn versions:
+    ``dict``, ``list``, and numpy structured array.
+    """
+    if isinstance(raw_labels, dict):
+        yield from raw_labels.items()
+    elif isinstance(raw_labels, list):
+        yield from enumerate(raw_labels)
+    else:
+        # numpy structured array with two columns
+        yield from raw_labels
+
+
+def _label_name(val: Any) -> str:
+    """Normalise a label value to a clean string."""
+    if isinstance(val, bytes):
+        val = val.decode("utf8")
+    name = str(val).replace("-", " ").replace("_", " ")
+    return name
+
+
+def _load_deterministic_atlas(
+    nl, atlas_name: str, params: dict, data_dir: Path
+) -> None:
+    """Load a deterministic atlas (e.g. Destrieux, Schaefer) as engine predicates."""
+    info = _ATLAS_REGISTRY[atlas_name]
+    fetch_kw = {
+        k: v
+        for k, v in params.items()
+        if k not in _ATLAS_FETCH_SKIP
+    }
+    fetch_kw.setdefault("data_dir", str(data_dir))
+    atl_data = info["fetch"](**fetch_kw)
+
+    from neurolang.regions import ExplicitVBR
+
+    img = nib.load(atl_data["maps"])
+    pred_name = params.get("predicate_name", atlas_name)
+    rows = []
+    for k, v in _parse_labels(atl_data["labels"]):
+        if k == 0:
+            continue
+        name = _label_name(v)
+        rows.append((name, ExplicitVBR.from_spatial_image_label(img, k)))
+
+    nl.add_tuple_set(rows, name=pred_name)
+
+
+def _load_probabilistic_atlas(
+    nl, atlas_name: str, params: dict, data_dir: Path
+) -> None:
+    """Load a probabilistic atlas (e.g. DiFuMo) as engine predicates.
+
+    Registers two predicates:
+
+    * ``{predicate_name}(component, region)`` — binary regions obtained by
+      thresholding each probability map (default threshold 0.5).
+    * ``{prob_predicate_name}(component, i, j, k, prob)`` — the raw
+      probability value at each voxel for each component (filtered by
+      ``prob_threshold``, default 0.01, to keep the set size manageable).
+    """
+    info = _ATLAS_REGISTRY[atlas_name]
+    fetch_kw = {
+        k: v
+        for k, v in params.items()
+        if k not in _ATLAS_FETCH_SKIP
+    }
+    fetch_kw.setdefault("data_dir", str(data_dir))
+    atl_data = info["fetch"](**fetch_kw)
+
+    from neurolang.regions import ExplicitVBR
+
+    img = nib.load(atl_data["maps"])
+    data = img.get_fdata()
+    labels = list(atl_data["labels"])
+    threshold = float(params.get("threshold", 0.5))
+    prob_threshold = float(params.get("prob_threshold", 0.01))
+    pred_name = params.get("predicate_name", atlas_name)
+    prob_pred_name = params.get(
+        "prob_predicate_name", f"{pred_name}_prob"
+    )
+
+    # ── Binary region predicate (thresholded) ──
+    region_rows = []
+    for i in range(data.shape[-1]):
+        mask = data[..., i] > threshold
+        if not mask.any():
+            continue
+        voxels = np.argwhere(mask)
+        region = ExplicitVBR(voxels, img.affine, image_dim=img.shape[:3])
+        label = _label_name(labels[i] if i < len(labels) else f"component_{i}")
+        region_rows.append((label, region))
+
+    nl.add_tuple_set(region_rows, name=pred_name)
+
+    # ── Probability predicate (component, i, j, k, prob) ──
+    prob_rows = []
+    for i in range(data.shape[-1]):
+        prob_map = data[..., i]
+        mask = prob_map > prob_threshold
+        if not mask.any():
+            continue
+        indices = np.argwhere(mask)
+        values = prob_map[mask]
+        label = _label_name(labels[i] if i < len(labels) else f"component_{i}")
+        for (j_idx, k_idx, l_idx), prob in zip(indices, values):
+            prob_rows.append((label, int(j_idx), int(k_idx), int(l_idx), float(prob)))
+
+    nl.add_tuple_set(prob_rows, name=prob_pred_name)
+
+
+def _load_atlas(
+    nl, atlas_name: str, params: dict, data_dir: Path
+) -> None:
+    """Download a brain atlas via nilearn and register it as a predicate."""
+    info = _ATLAS_REGISTRY.get(atlas_name)
+    if info is None:
+        raise ValueError(
+            f"Unknown atlas {atlas_name!r}. "
+            f"Available: {', '.join(sorted(_ATLAS_REGISTRY))}"
+        )
+    if info["probabilistic"]:
+        _load_probabilistic_atlas(nl, atlas_name, params, data_dir)
+    else:
+        _load_deterministic_atlas(nl, atlas_name, params, data_dir)
+
+
+def _get_mni_mask(data_dir: Path) -> nib.Nifti1Image:
+    return nib.load(
+        datasets.fetch_icbm152_2009(
+            data_dir=str(data_dir / "icbm")
+        )["t1"]
+    )
+
+
+def _resolve_mask(
+    cfg: dict, data_dir: Path, resolution: Optional[float] = None
+) -> Optional[nib.Nifti1Image]:
+    """Download the MNI mask if required by the engine config."""
+    if not cfg.get("requires_mni_mask", False):
+        return None
+    mask = _get_mni_mask(data_dir)
+    if resolution is not None:
+        mask = image.resample_img(mask, np.eye(4) * resolution)
+    return mask
+
+
+def _phase_builtins(nl, cfg):
+    for sym_name in cfg.get("builtins", []):
+        func = _BUILTIN_SYMBOLS.get(sym_name)
+        if func is not None:
+            nl.add_symbol(func, name=sym_name)
+
+
+def _phase_python_init(nl, cfg, mask, data_dir):
+    py_init = cfg.get("python_init")
+    if not py_init:
+        return
+    import importlib
+
+    mod = importlib.import_module(py_init)
+    mod.init_engine(nl, mask, data_dir)
+
+
+def _phase_downloads(cfg, data_dir, engine_name):
+    for dl_entry in cfg.get("downloads", []):
+        url = dl_entry["url"]
+        dl_dest = str(data_dir / dl_entry.get("dest", engine_name))
+        extract_members = dl_entry.get("extract", [])
+        if isinstance(extract_members, bool):
+            archive_name = Path(url).name
+            _fetch_files(dl_dest, [(archive_name, url, {"uncompress": True})], verbose=1)
+        elif extract_members:
+            files = [(m, url, {"uncompress": True}) for m in extract_members]
+            _fetch_files(dl_dest, files, verbose=1)
+        else:
+            file_name = Path(url).name
+            _fetch_files(dl_dest, [(file_name, url, {})], verbose=1)
+
+
+def _phase_templates(nl, cfg, data_dir, engine_name):
+    for tpl_name, tpl_params in cfg.get("templates", {}).items():
+        _load_template(nl, tpl_name, tpl_params, data_dir / engine_name)
+
+
+def _phase_atlases(nl, cfg, data_dir, engine_name):
+    for atl_name, atl_params in cfg.get("atlases", {}).items():
+        _load_atlas(nl, atl_name, atl_params, data_dir / engine_name)
+
+
+def _phase_datalog_init(nl, cfg):
+    datalog_init = cfg.get("datalog_init")
+    precompute = set(cfg.get("precompute", []))
+    if not datalog_init:
+        return
+
+    intermediate = nl.datalog_parser(datalog_init)
+
+    if not precompute:
+        nl.program_ir.walk(intermediate)
+        return
+
+    # Separate rules: precomputed predicates are materialised eagerly;
+    # all others remain as IDB rules evaluated lazily by the chase.
+    import neurolang.expressions as ir
+    from neurolang.datalog.expressions import Implication
+    from neurolang.logic import Union as LogicUnion
+
+    regular_formulas = []
+    precompute_formulas = []
+    for formula in intermediate.formulas:
+        if isinstance(formula, Implication):
+            head_name = formula.consequent.functor.name
+            if head_name in precompute:
+                precompute_formulas.append(formula)
+            else:
+                regular_formulas.append(formula)
+        else:
+            regular_formulas.append(formula)
+
+    if regular_formulas:
+        nl.program_ir.walk(LogicUnion(regular_formulas))
+
+    if precompute_formulas:
+        # Add precompute rules temporarily, materialise via chase,
+        # then swap the IDB entry for the EDB result set.
+        nl.program_ir.walk(LogicUnion(precompute_formulas))
+        solution = nl.solve_all()
+        for pred_name in list(precompute):
+            if pred_name not in solution:
+                continue
+            from neurolang.type_system import AbstractSet as AbstractSetType
+            result_set = solution[pred_name]
+            new_value = ir.Constant[AbstractSetType[result_set.row_type]](result_set)
+            for key in list(nl.symbol_table.keys()):
+                if key.name == pred_name:
+                    nl.symbol_table[key] = new_value
+                    break
+
+
+def _phase_relations(nl, cfg, engine_name, data_dir, rel_base_dir):
+    relations = cfg.get("relations", {})
+    if not relations:
+        return
+    import pandas as pd
+
+    for rel_name, rel_cfg in relations.items():
+        if isinstance(rel_cfg, str):
+            rel_cfg = {"file": rel_cfg}
+        rel_path = _resolve_relation_file(
+            rel_cfg, engine_name, data_dir, base_dir=rel_base_dir
+        )
+        name_lower = rel_path.name.lower()
+        if name_lower.endswith(".csv") or name_lower.endswith(".csv.gz"):
+            sep = ","
+        elif name_lower.endswith(".tsv") or name_lower.endswith(".tsv.gz"):
+            sep = "\t"
+        else:
+            raise ValueError(
+                f"Unsupported relation file format: {rel_path.suffix} "
+                f"for relation {rel_name!r}. "
+                "Supported: .csv, .tsv, .csv.gz, .tsv.gz"
+            )
+        df = pd.read_csv(rel_path, sep=sep)
+        nl.add_tuple_set(
+            [tuple(row) for row in df.to_numpy()], name=rel_name
+        )
+
+
+def _phase_probabilistic_choices(nl, cfg):
+    for ch_name, ch_cfg in cfg.get("probabilistic_choice", {}).items():
+        source_val = nl.symbols[ch_cfg["source"]]
+        if hasattr(source_val, "value"):
+            source_val = source_val.value
+        nl.add_uniform_probabilistic_choice_over_set(
+            source_val, name=ch_name
+        )
+
+
+def _phase_ontologies(nl, cfg, data_dir, engine_name):
+    for onto_cfg in cfg.get("ontologies", []):
+        url = onto_cfg["url"]
+        onto_dir = str(data_dir / engine_name)
+        onto_file = Path(url).name
+        result = _fetch_files(onto_dir, [(onto_file, url, {})], verbose=1)
+        nl.load_ontology(result[0])
+
+
+def build_engine(
+    name: str,
+    data_dir: Path,
+    resolution: Optional[float] = None,
+    yaml_path: Optional[Path] = None,
+) -> "NeurolangPDL":
+    """Create and populate a :class:`NeurolangPDL` engine from its
+    declarative YAML config.
+
+    Parameters
+    ----------
+    name :
+        Registered engine name (e.g. ``"neurosynth"``, ``"destrieux"``).
+    data_dir :
+        Directory under which downloaded data is cached.
+    resolution :
+        If set, resample the MNI mask to the given isotropic resolution (mm).
+    yaml_path :
+        Path to an engine YAML file.  Defaults to the built-in
+        ``engines/engines.yaml``.
+
+    Returns
+    -------
+    NeurolangPDL
+        A fully initialised engine ready for query execution.
+
+    Raises
+    ------
+    ValueError
+        If *name* is not a registered engine.
+    ImportError
+        If the engine's Python init module cannot be loaded.
+    """
+    from neurolang.frontend import NeurolangPDL
+
+    cfg = get_engine_config(name, yaml_path)
+    data_dir = Path(data_dir)
+    rel_base_dir = (Path(yaml_path).parent if yaml_path else None)
+    mask = _resolve_mask(cfg, data_dir, resolution)
+
+    nl = NeurolangPDL()
+
+    _phase_builtins(nl, cfg)
+    _phase_python_init(nl, cfg, mask, data_dir)
+    _phase_downloads(cfg, data_dir, name)
+    _phase_templates(nl, cfg, data_dir, name)
+    _phase_atlases(nl, cfg, data_dir, name)
+    _phase_datalog_init(nl, cfg)
+    _phase_relations(nl, cfg, name, data_dir, rel_base_dir)
+    _phase_probabilistic_choices(nl, cfg)
+    _phase_ontologies(nl, cfg, data_dir, name)
+
+    return nl

--- a/neurolang/utils/engines/__init__.py
+++ b/neurolang/utils/engines/__init__.py
@@ -1,0 +1,18 @@
+"""
+Declarative engine definitions for the Neurolang-query CLI.
+
+Engines are declared in ``engines.yaml``, which provides metadata
+(description, predicates) and points to Python initialization scripts.
+Each engine's init script is a Python module that exports::
+
+    def init_engine(
+        nl: NeurolangPDL,
+        mask: nib.Nifti1Image,
+        data_dir: Path,
+    ) -> None:
+        ...
+
+The engine registry in :mod:`neurolang.utils.engine_registry` handles
+loading the YAML, calling init scripts, and building fully-configured
+:class:`~neurolang.frontend.NeurolangPDL` instances.
+"""

--- a/neurolang/utils/engines/base.py
+++ b/neurolang/utils/engines/base.py
@@ -1,0 +1,69 @@
+"""Shared symbols and utilities for all neuroimaging engines."""
+
+from typing import Callable, Iterable
+
+import nibabel as nib
+import numpy as np
+
+from neurolang.frontend import NeurolangPDL
+from neurolang.regions import ExplicitVBR, ExplicitVBROverlay
+
+
+def init_base_engine(
+    nl: NeurolangPDL, mask: nib.Nifti1Image
+) -> None:
+    """Register symbols common to all neuroimaging engines.
+
+    Parameters
+    ----------
+    nl :
+        Fresh :class:`~neurolang.frontend.NeurolangPDL` instance.
+    mask :
+        MNI template image for voxel-space coordinate mapping.
+    """
+    @nl.add_symbol
+    def agg_count(i: Iterable) -> np.int64:
+        return np.int64(len(i))
+
+    @nl.add_symbol
+    def agg_create_region(
+        i: Iterable, j: Iterable, k: Iterable
+    ) -> ExplicitVBR:
+        voxels = np.c_[i, j, k]
+        return ExplicitVBR(
+            voxels, mask.affine, image_dim=mask.shape
+        )
+
+    @nl.add_symbol
+    def agg_create_region_overlay(
+        i: Iterable, j: Iterable, k: Iterable, p: Iterable
+    ) -> ExplicitVBROverlay:
+        voxels = np.c_[i, j, k]
+        return ExplicitVBROverlay(
+            voxels, mask.affine, p, image_dim=mask.shape
+        )
+
+    @nl.add_symbol
+    def principal_direction(
+        s: ExplicitVBR, direction: str, eps: float = 1e-6
+    ) -> bool:
+        c_labels = ["LR", "AP", "SI"]
+        s_xyz = s.to_xyz()
+        cov = np.cov(s_xyz.T)
+        evals, evecs = np.linalg.eig(cov)
+        i = np.argmax(np.abs(evals))
+        abs_max_evec = np.abs(evecs[:, i].squeeze())
+        sort_dir = np.argsort(abs_max_evec)
+        if (
+            np.abs(
+                abs_max_evec[sort_dir[-1]]
+                - abs_max_evec[sort_dir[-2]]
+            )
+            < eps
+        ):
+            return False
+        else:
+            main_dir = c_labels[sort_dir[-1]]
+        return (direction == main_dir) or (
+            direction[::-1] == main_dir
+        )

--- a/neurolang/utils/engines/destrieux/__init__.py
+++ b/neurolang/utils/engines/destrieux/__init__.py
@@ -1,0 +1,1 @@
+"""Destrieux atlas engine initialization."""

--- a/neurolang/utils/engines/destrieux/init.py
+++ b/neurolang/utils/engines/destrieux/init.py
@@ -1,0 +1,44 @@
+"""Destrieux atlas engine initialization.
+
+Registers the following symbols:
+
+* ``region_union`` — aggregates an iterable of regions into a single
+  :class:`~neurolang.regions.ExplicitVBR`.
+* Base engine symbols (``agg_count``, ``agg_create_region``,
+  ``agg_create_region_overlay``, ``principal_direction``).
+
+The ``destrieux`` predicate itself is loaded from the YAML ``atlases:``
+section.
+"""
+
+from pathlib import Path
+from typing import Callable, Iterable
+
+import nibabel as nib
+
+from neurolang.frontend import NeurolangPDL
+from neurolang.regions import ExplicitVBR, region_union
+from neurolang.utils.engines.base import init_base_engine
+
+
+def init_engine(
+    nl: NeurolangPDL, mask: nib.Nifti1Image, data_dir: Path
+) -> None:
+    """Populate a fresh engine with Destrieux atlas symbols.
+
+    Parameters
+    ----------
+    nl :
+        Fresh :class:`~neurolang.frontend.NeurolangPDL` instance.
+    mask :
+        MNI template image (used for base symbol registration).
+    data_dir :
+        Directory under which downloaded data is cached.
+    """
+    init_base_engine(nl, mask)
+
+    nl.add_symbol(
+        region_union,
+        name="region_union",
+        type_=Callable[[Iterable[ExplicitVBR]], ExplicitVBR],
+    )

--- a/neurolang/utils/engines/engines.yaml
+++ b/neurolang/utils/engines/engines.yaml
@@ -1,0 +1,88 @@
+engines:
+  neurosynth:
+    description: >
+      Neurosynth database — forward and reverse inference over
+      reported activation peaks, TF-IDF term frequencies, and a
+      probabilistic choice over studies.
+    requires_mni_mask: true
+    builtins: [exp, log, startswith]
+    python_init: "neurolang.utils.engines.neurosynth.init"
+    datalog_init: |
+      study_with_peaks(S) :- peak_reported(I, J, K, S)
+      origin_peak(I, J, K, S) :- peak_reported(I, J, K, S), I == 0
+    probabilistic_choice:
+      selected_study:
+        source: study
+        description: "Uniform probabilistic choice over studies"
+    predicates:
+      peak_reported:
+        arity: 4
+        columns: [i, j, k, study_id]
+        description: "Reported activation peaks in voxel coordinates"
+      study:
+        arity: 1
+        columns: [study_id]
+        description: "All study identifiers"
+      term_in_study_tfidf:
+        arity: 3
+        columns: [term, tfidf, study_id]
+        description: "Term frequency–inverse document frequency values"
+      selected_study:
+        arity: 1
+        columns: [study_id]
+        description: "Uniform probabilistic choice over studies"
+      voxel:
+        arity: 3
+        columns: [i, j, k]
+        description: "Every voxel inside the MNI mask"
+
+  destrieux:
+    description: >
+      Destrieux 2009 cortical atlas — region definitions for the
+      Destrieux cortical parcellation, each mapped to a volumetric
+      brain region (ExplicitVBR).
+    requires_mni_mask: true
+    builtins: [exp, log, startswith]
+    python_init: "neurolang.utils.engines.destrieux.init"
+    atlases:
+      destrieux:
+        predicate_name: destrieux
+        description: "Cortical region name and ExplicitVBR geometry"
+    precompute: [destrieux_voxel]
+    datalog_init: |
+      left_region(N, R) :- destrieux(N, R), startswith('lh', N)
+      right_region(N, R) :- destrieux(N, R), startswith('rh', N)
+      destrieux_voxel(N, I, J, K) :- destrieux(N, R), contains(R, (I, J, K))
+    predicates:
+      destrieux:
+        arity: 2
+        columns: [name, region]
+        description: "Cortical region name and ExplicitVBR geometry"
+      destrieux_voxel:
+        arity: 4
+        columns: [name, i, j, k]
+        description: "Individual voxel coordinates for each Destrieux region"
+
+  # Example template usage (commented out — uncomment to enable):
+  #
+  #   template_demo:
+  #     description: "Demonstrates declarative template loading"
+  #     requires_mni_mask: false
+  #     builtins: [exp, log, startswith]
+  #     templates:
+  #       # Nilearn brain mask → voxel(i, j, k) predicate
+  #       mni_brain:
+  #         source: nilearn
+  #         variant: brain_mask
+  #         predicate: voxel
+  #       # Nilearn T1 template (2mm) — just download, no predicate
+  #       mni_t1:
+  #         source: nilearn
+  #         variant: template
+  #         resolution: 2
+  #       # TemplateFlow T1 template at 1mm — requires ``pip install templateflow``
+  #       t1_highres:
+  #         source: templateflow
+  #         template: MNI152NLin2009cAsym
+  #         resolution: 1
+  #         suffix: T1w

--- a/neurolang/utils/engines/neurosynth/__init__.py
+++ b/neurolang/utils/engines/neurosynth/__init__.py
@@ -1,0 +1,1 @@
+"""NeuroSynth engine initialization."""

--- a/neurolang/utils/engines/neurosynth/init.py
+++ b/neurolang/utils/engines/neurosynth/init.py
@@ -1,0 +1,158 @@
+"""NeuroSynth engine initialization.
+
+Registers the following predicates:
+
+* ``peak_reported(i, j, k, study_id)`` — reported activation peaks
+  converted to voxel coordinates.
+* ``study(study_id)`` — all study identifiers.
+* ``term_in_study_tfidf(term, tfidf, study_id)`` — term frequency–inverse
+  document frequency values.
+* ``selected_study(study_id)`` — uniform probabilistic choice over
+  studies.
+* ``voxel(i, j, k)`` — every voxel inside the MNI mask.
+
+Predicate names are lowercase to match SQUALL's case-folding convention
+(see ``intransitive`` in ``squall_syntax_lark.py``).
+"""
+
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import pandas as pd
+
+from neurolang.frontend import NeurolangPDL
+from neurolang.frontend.neurosynth_utils import StudyID
+from neurolang.utils.engines.base import init_base_engine
+
+try:
+    from nilearn.datasets.utils import _fetch_files
+except ImportError:
+    from nilearn.datasets._utils import fetch_files as _fetch_files
+
+
+def init_engine(
+    nl: NeurolangPDL, mask: nib.Nifti1Image, data_dir: Path
+) -> None:
+    """Populate a fresh engine with NeuroSynth data.
+
+    Parameters
+    ----------
+    nl :
+        Fresh :class:`~neurolang.frontend.NeurolangPDL` instance.
+    mask :
+        MNI template image for voxel-space coordinate mapping.
+    data_dir :
+        Directory under which downloaded data is cached.
+    """
+    init_base_engine(nl, mask)
+
+    ns_database_fn, ns_features_fn = _fetch_files(
+        str(data_dir / "neurosynth"),
+        [
+            (
+                "database.txt",
+                "https://github.com/neurosynth/neurosynth-data"
+                "/raw/master/current_data.tar.gz",
+                {"uncompress": True},
+            ),
+            (
+                "features.txt",
+                "https://github.com/neurosynth/neurosynth-data"
+                "/raw/master/current_data.tar.gz",
+                {"uncompress": True},
+            ),
+        ],
+    )
+
+    activations = _read_ns_database(ns_database_fn)
+    peak_data = _process_peaks(activations, mask)
+    study_ids = peak_data[["study_id"]].drop_duplicates()
+
+    features = _read_ns_features(ns_features_fn)
+    term_data = features.melt(
+        var_name="term", id_vars="study_id", value_name="tfidf"
+    ).query("tfidf > 1e-3")[["term", "tfidf", "study_id"]]
+    term_data["study_id"] = term_data["study_id"].apply(StudyID)
+
+    nl.add_tuple_set(peak_data, name="peak_reported")
+    nl.add_tuple_set(study_ids, name="study")
+    nl.add_tuple_set(term_data, name="term_in_study_tfidf")
+    nl.add_tuple_set(
+        np.hstack(
+            np.meshgrid(
+                *(np.arange(0, dim) for dim in mask.get_fdata().shape)
+            )
+        )
+        .swapaxes(0, 1)
+        .reshape(3, -1)
+        .T,
+        name="voxel",
+    )
+
+
+def _read_ns_database(path: str) -> pd.DataFrame:
+    activations = pd.read_csv(path, sep="\t")
+    activations["id"] = activations["id"].apply(StudyID)
+    return activations
+
+
+def _process_peaks(
+    activations: pd.DataFrame, mni_mask: nib.Nifti1Image
+) -> pd.DataFrame:
+    """Convert MNI / Talairach peak coordinates to voxel indices."""
+    mni_peaks = activations.loc[activations.space == "MNI"][
+        ["x", "y", "z", "id"]
+    ].rename(columns={"id": "study_id"})
+    non_mni_peaks = activations.loc[activations.space != "MNI"][
+        ["x", "y", "z", "id"]
+    ].rename(columns={"id": "study_id"})
+
+    proj_mat = np.linalg.pinv(
+        np.array(
+            [
+                [0.9254, 0.0024, -0.0118, -1.0207],
+                [-0.0048, 0.9316, -0.0871, -1.7667],
+                [0.0152, 0.0883, 0.8924, 4.0926],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ).T
+    )
+    projected = np.round(
+        np.dot(
+            np.hstack(
+                (
+                    non_mni_peaks[["x", "y", "z"]].values,
+                    np.ones((len(non_mni_peaks), 1)),
+                )
+            ),
+            proj_mat,
+        )[:, 0:3]
+    )
+    projected_df = pd.DataFrame(
+        np.hstack(
+            [projected, non_mni_peaks[["study_id"]].values]
+        ),
+        columns=["x", "y", "z", "study_id"],
+    )
+    peak_data = pd.concat([projected_df, mni_peaks]).astype(
+        {"x": int, "y": int, "z": int}
+    )
+
+    ijk_positions = np.round(
+        nib.affines.apply_affine(
+            np.linalg.inv(mni_mask.affine),
+            peak_data[["x", "y", "z"]].values.astype(float),
+        )
+    ).astype(int)
+    peak_data["i"] = ijk_positions[:, 0]
+    peak_data["j"] = ijk_positions[:, 1]
+    peak_data["k"] = ijk_positions[:, 2]
+    peak_data = peak_data[["i", "j", "k", "study_id"]]
+    return peak_data
+
+
+def _read_ns_features(path: str) -> pd.DataFrame:
+    features = pd.read_csv(path, sep="\t")
+    features.rename(columns={"pmid": "study_id"}, inplace=True)
+    return features

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -720,23 +720,37 @@ class NamedRelationalAlgebraFrozenSet(
         if self._container is None:
             return self.copy()
 
+        # Convert column values with a voxels attribute (e.g. ExplicitVBR)
+        # into iterable tuples so pandas .explode() can flatten them.
+        container = self._container
+        if len(container) > 0:
+            col = container[src_column]
+            first = col.iloc[0]
+            if hasattr(first, 'voxels') and not isinstance(first, (str, bytes)):
+                container = container.copy()
+                container[src_column] = col.apply(
+                    lambda v: tuple(map(tuple, getattr(v, 'voxels', ())))
+                )
+
         if dst_columns == src_column:
             # 1. replace original column by exploded one
-            new_container = self._container.explode(
+            new_container = container.explode(
                 src_column, ignore_index=True
             )
             new_columns = self.columns
         elif not isinstance(dst_columns, tuple):
             # 2. add new column with exploded values
-            new_container = self._container.assign(
-                **{dst_columns: self._container[src_column]}
+            new_container = container.assign(
+                **{dst_columns: container[src_column]}
             ).explode(dst_columns, ignore_index=True)
             new_columns = self.columns + (dst_columns,)
         else:
             # 3. explode values into multiple columns
-            new_container = self._container.assign(
-                **{dst_columns[-1]: self._container[src_column]}
+            new_container = container.assign(
+                **{dst_columns[-1]: container[src_column]}
             ).explode(dst_columns[-1], ignore_index=True)
+            # Drop rows where the explode produced NaN (empty source values)
+            new_container = new_container.dropna(subset=[dst_columns[-1]])
             for c, v in zip(dst_columns, zip(*new_container[dst_columns[-1]])):
                 new_container[c] = v
             new_columns = self.columns + dst_columns

--- a/neurolang/utils/tests/test_cli.py
+++ b/neurolang/utils/tests/test_cli.py
@@ -1,0 +1,525 @@
+"""
+Tests for the neurolang-query CLI module.
+"""
+
+import pytest
+
+from neurolang.utils.cli import (
+    _build_parser,
+    _execute_program,
+    _execute_squall_program,
+    _format_result,
+)
+
+from neurolang.utils import engine_registry
+
+# ---------------------------------------------------------------------------
+# _build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_defaults(self):
+        parser = _build_parser()
+        args = parser.parse_args([])
+        assert args.query is None
+        assert args.file is None
+        assert args.engine == "neurosynth"
+        assert args.format == "table"
+        assert args.data_dir == "neurolang_data"
+        assert args.resolution is None
+        assert args.list_predicates is False
+
+    def test_positional_query(self):
+        parser = _build_parser()
+        args = parser.parse_args(["ans(x) :- R(x)"])
+        assert args.query == "ans(x) :- R(x)"
+        assert args.file is None
+
+    def test_file_arg(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--file", "/tmp/q.dl"])
+        assert args.file == "/tmp/q.dl"
+        assert args.query is None
+
+    def test_engine(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--engine", "destrieux"])
+        assert args.engine == "destrieux"
+
+    def test_invalid_engine_in_main(self):
+        """Validation now lives in main(), not the parser."""
+        from neurolang.utils.cli import main
+
+        with pytest.raises(SystemExit):
+            main(["--engine", "unknown", "ans(x) :- R(x)"])
+
+    def test_format(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--format", "csv"])
+        assert args.format == "csv"
+
+    def test_invalid_format(self):
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--format", "xml"])
+
+    def test_list_predicates(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--list-predicates"])
+        assert args.list_predicates is True
+
+    def test_resolution(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--resolution", "2.0"])
+        assert args.resolution == 2.0
+
+    def test_data_dir(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--data-dir", "/custom/path"])
+        assert args.data_dir == "/custom/path"
+
+    def test_mutually_exclusive_query_and_file(self):
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["ans(x) :- R(x)", "--file", "/tmp/q.dl"])
+
+    def test_short_flags(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-e", "destrieux", "-f", "/tmp/q.dl", "-l"])
+        assert args.engine == "destrieux"
+        assert args.file == "/tmp/q.dl"
+        assert args.list_predicates is True
+
+    def test_list_engines_flag(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--list-engines"])
+        assert args.list_engines is True
+
+    def test_engine_not_rejected_by_parser_anymore(self):
+        """The parser no longer validates engine names; main() does."""
+        parser = _build_parser()
+        args = parser.parse_args(["--engine", "unknown"])
+        assert args.engine == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Engine registry
+# ---------------------------------------------------------------------------
+
+
+class TestEngineRegistry:
+    def test_list_engine_names(self):
+        names = engine_registry.list_engine_names()
+        assert "neurosynth" in names
+        assert "destrieux" in names
+
+    def test_get_engine_config(self):
+        cfg = engine_registry.get_engine_config("neurosynth")
+        assert "python_init" in cfg
+        assert cfg["requires_mni_mask"] is True
+        assert "predicates" in cfg
+        assert "peak_reported" in cfg["predicates"]
+
+    def test_get_predicates(self):
+        preds = engine_registry.get_predicates("destrieux")
+        assert "destrieux" in preds
+        assert preds["destrieux"]["arity"] == 2
+
+    def test_unknown_engine_raises(self):
+        with pytest.raises(ValueError, match="Unknown engine"):
+            engine_registry.get_engine_config("nonexistent")
+
+    def test_datalog_init_in_config(self):
+        """Every engine with python_init should have inline datalog_init."""
+        for name in engine_registry.list_engine_names():
+            cfg = engine_registry.get_engine_config(name)
+            if "python_init" in cfg:
+                code = cfg.get("datalog_init")
+                assert code, (
+                    f"Engine {name!r} has python_init but no datalog_init"
+                )
+                assert isinstance(code, str), (
+                    f"datalog_init for engine {name!r} must be a string, "
+                    f"got {type(code).__name__}"
+                )
+                assert len(code.strip()) > 0, (
+                    f"datalog_init for engine {name!r} is empty"
+                )
+
+    def test_show_engines(self, capsys):
+        """show_engines prints all engine names with descriptions."""
+        engine_registry.show_engines()
+        captured = capsys.readouterr()
+        assert "neurosynth" in captured.out
+        assert "destrieux" in captured.out
+        assert "Available engines" in captured.out
+
+    def test_get_engine_config_with_yaml_path(self, tmp_path):
+        """get_engine_config accepts a custom YAML path."""
+        custom_yaml = tmp_path / "engines.yaml"
+        custom_yaml.write_text("""
+engines:
+  mini:
+    description: "Mini test"
+    builtins: []
+""")
+        cfg = engine_registry.get_engine_config("mini", yaml_path=custom_yaml)
+        assert cfg["description"] == "Mini test"
+
+    def test_get_predicates_with_yaml_path(self, tmp_path):
+        """get_predicates works with a custom YAML file."""
+        custom_yaml = tmp_path / "engines.yaml"
+        custom_yaml.write_text("""
+engines:
+  mini:
+    description: "Mini"
+    builtins: []
+    predicates:
+      p:
+        arity: 1
+        columns: [x]
+        description: "Test predicate"
+""")
+        preds = engine_registry.get_predicates("mini", yaml_path=custom_yaml)
+        assert "p" in preds
+        assert preds["p"]["arity"] == 1
+
+    def test_edb_program_roundtrip(self):
+        """In-memory EDB relations can be queried and formatted."""
+        from neurolang.utils.cli import _execute_program, _format_result
+
+        from neurolang.frontend import NeurolangPDL
+
+        nl = NeurolangPDL()
+        nl.add_tuple_set([(1, "a"), (2, "b"), (3, "c")], name="csv_rel")
+        nl.add_tuple_set([(4, "d"), (5, "e")], name="tsv_rel")
+
+        # Query CSV relation — _execute_program bypasses the probabilistic
+        # frontend query path (which doesn't handle EDB-only queries).
+        result, col_names = _execute_program(
+            nl, "ans(x, y) :- csv_rel(x, y)"
+        )
+        assert col_names == ["x", "y"]
+        assert result is not None
+        output = _format_result(result, column_names=col_names)
+        assert "a" in output
+        assert "b" in output
+        assert "c" in output
+
+        # Query TSV relation
+        result, col_names = _execute_program(
+            nl, "ans(x, y) :- tsv_rel(x, y)"
+        )
+        assert col_names == ["x", "y"]
+        assert result is not None
+        output = _format_result(result, column_names=col_names)
+        assert "d" in output
+        assert "e" in output
+
+
+# ---------------------------------------------------------------------------
+# _format_result
+# ---------------------------------------------------------------------------
+
+
+class TestFormatResult:
+    def test_none(self):
+        assert _format_result(None) == ""
+
+    def test_true(self):
+        assert _format_result(True) == "true"
+
+    def test_false(self):
+        assert _format_result(False) == "false"
+
+    def test_empty_unnamed_set(self):
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        ras = RelationalAlgebraSet()
+        assert _format_result(ras) == "(empty)"
+
+    def test_nonempty_unnamed_set(self):
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        ras = RelationalAlgebraSet()
+        ras.add((1, "a"))
+        ras.add((2, "b"))
+        result = _format_result(ras)
+        assert "1" in result
+        assert "a" in result
+
+    def test_unnamed_set_with_column_names(self):
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        ras = RelationalAlgebraSet()
+        ras.add((1,))
+        ras.add((2,))
+        result = _format_result(ras, column_names=["x"])
+        assert "x" in result
+        assert "1" in result
+        assert "2" in result
+
+    def test_named_set_preserves_columns(self):
+        from neurolang.utils.relational_algebra_set.pandas import (
+            NamedRelationalAlgebraFrozenSet,
+        )
+
+        nras = NamedRelationalAlgebraFrozenSet(
+            columns=("x", "y"), iterable=[(1, "a"), (2, "b")]
+        )
+        result = _format_result(nras)
+        assert "x" in result
+        assert "y" in result
+
+    def test_constant_wrapping_wrapped_set(self):
+        """The typical chase result: Constant[WrappedRelationalAlgebraSet]."""
+        from neurolang import expressions as ir
+        from neurolang.datalog.wrapped_collections import (
+            WrappedRelationalAlgebraSet,
+        )
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        inner = RelationalAlgebraSet()
+        inner.add((42,))
+        inner.add((99,))
+        wrapped = WrappedRelationalAlgebraSet(inner)
+        result = ir.Constant(wrapped)
+
+        output = _format_result(result, column_names=["val"])
+        assert "val" in output
+        assert "42" in output
+        assert "99" in output
+
+    def test_csv_format(self):
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        ras = RelationalAlgebraSet()
+        ras.add((1, "a"))
+        result = _format_result(ras, fmt="csv", column_names=["x", "y"])
+        assert "x,y" in result.split("\n")[0]
+        assert "1,a" in result.split("\n")[1]
+
+    def test_json_format(self):
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        ras = RelationalAlgebraSet()
+        ras.add((1, "a"))
+        result = _format_result(ras, fmt="json", column_names=["x", "y"])
+        assert '"x"' in result
+        assert '"y"' in result
+        assert '"a"' in result
+        assert "1" in result  # numbers are unquoted in JSON
+
+    def test_column_names_mismatch_arity(self):
+        """When column_names length doesn't match, they are ignored."""
+        from neurolang.utils.relational_algebra_set.pandas import (
+            RelationalAlgebraSet,
+        )
+
+        ras = RelationalAlgebraSet()
+        ras.add((1,))
+        # 2 column names for 1-column data — no renaming
+        result = _format_result(ras, column_names=["a", "b"])
+        # Default integer column name stays
+        assert "0" in result
+
+    def test_column_names_not_applied_to_named_sets(self):
+        """column_names is only applied when existing columns are unnamed."""
+        from neurolang.utils.relational_algebra_set.pandas import (
+            NamedRelationalAlgebraFrozenSet,
+        )
+
+        nras = NamedRelationalAlgebraFrozenSet(columns=("x",), iterable=[(1,)])
+        result = _format_result(nras, column_names=["y"])
+        # Existing name 'x' is preserved
+        assert "x" in result
+        assert "y" not in result
+
+
+# ---------------------------------------------------------------------------
+# _execute_program
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteProgram:
+    """Integration tests with a real NeurolangPDL engine and tiny data."""
+
+    @pytest.fixture
+    def nl(self):
+        """Return a fresh NeurolangPDL with a small EDB loaded."""
+        from neurolang.frontend import NeurolangPDL
+
+        nl = NeurolangPDL()
+        nl.add_tuple_set([(1, "a"), (2, "b"), (3, "c")], name="R")
+        nl.add_tuple_set([(1, 10.0), (2, 20.0), (3, 30.0)], name="S")
+        return nl
+
+    def test_no_query(self, nl):
+        # A fact-only program has no Query expression → returns None
+        result = _execute_program(nl, "T(x) :- R(x, y)")
+        assert result is None
+
+    def test_simple_edb_query(self, nl):
+        result, col_names = _execute_program(nl, "ans(x) :- R(x, y)")
+        assert col_names == ["x"]
+        assert result is not None
+
+    def test_query_with_conjunction(self, nl):
+        result, col_names = _execute_program(
+            nl, "ans(x, z) :- R(x, y) & S(x, z)"
+        )
+        assert col_names == ["x", "z"]
+        assert result is not None
+
+    def test_query_with_comparison(self, nl):
+        result, col_names = _execute_program(
+            nl, "ans(x) :- S(x, z) & (z > 15.0)"
+        )
+        assert col_names == ["x"]
+        assert result is not None
+
+    def test_query_projection(self, nl):
+        """Project only one of the variables."""
+        result, col_names = _execute_program(
+            nl, "ans(y) :- R(x, y) & S(x, z) & (z > 10.0)"
+        )
+        assert col_names == ["y"]
+        assert result is not None
+
+    def test_query_no_matching_results(self, nl):
+        result = _execute_program(nl, "ans(x) :- R(x, y) & (x > 100)")
+        # Chase may return None when a predicate yields no tuples
+        assert result is None
+
+    def test_multiple_queries_raises(self, nl):
+        with pytest.raises(ValueError, match="single query"):
+            _execute_program(nl, "ans(x) :- R(x, y)\nans(z) :- S(z, w)")
+
+    def test_result_column_names_preserved(self, nl):
+        """column_names match the Datalog variable names in the query."""
+        _, col_names = _execute_program(
+            nl, "ans(the_x, the_y) :- R(the_x, the_y)"
+        )
+        assert col_names == ["the_x", "the_y"]
+
+    def test_table_format_output_has_column_names(self, nl):
+        """Full roundtrip: execute → format with column names."""
+        result, col_names = _execute_program(
+            nl, "ans(val) :- R(x, y) & S(x, val)"
+        )
+        output = _format_result(result, column_names=col_names)
+        assert "val" in output
+        assert "10.0" in output
+        assert "20.0" in output
+        assert "30.0" in output
+
+    def test_csv_output_has_header(self, nl):
+        result, col_names = _execute_program(nl, "ans(v) :- R(x, y) & S(x, v)")
+        output = _format_result(result, fmt="csv", column_names=col_names)
+        lines = output.strip().split("\n")
+        assert lines[0] == "v"
+
+
+# ---------------------------------------------------------------------------
+# --squall flag
+# ---------------------------------------------------------------------------
+
+
+class TestSquallFlag:
+    def test_squall_defaults_to_false(self):
+        parser = _build_parser()
+        args = parser.parse_args([])
+        assert args.squall is False
+
+    def test_squall_flag_long(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--squall", "obtain every Person."])
+        assert args.squall is True
+        assert args.query == "obtain every Person."
+
+    def test_squall_flag_short(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-s", "obtain every Person."])
+        assert args.squall is True
+        assert args.query == "obtain every Person."
+
+    def test_squall_with_file(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-s", "-f", "/tmp/q.squall"])
+        assert args.squall is True
+        assert args.file == "/tmp/q.squall"
+
+
+# ---------------------------------------------------------------------------
+# _execute_squall_program
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSquallProgram:
+    """Integration tests with a real NeurolangPDL engine and squall queries."""
+
+    @pytest.fixture
+    def nl(self):
+        from neurolang.frontend import NeurolangPDL
+
+        nl = NeurolangPDL()
+        nl.add_tuple_set([("alice",), ("bob",)], name="person")
+        nl.add_tuple_set([("alice",)], name="plays")
+        return nl
+
+    def test_single_obtain_returns_set(self, nl):
+        result = _execute_squall_program(
+            nl, "obtain every Person that plays."
+        )
+        df = result.as_pandas_dataframe()
+        assert len(df) == 1
+        assert df.iloc[0, 0] == "alice"
+
+    def test_rules_only_returns_none(self, nl):
+        result = _execute_squall_program(
+            nl, "define as Active every person that plays."
+        )
+        assert result is None
+
+    def test_multiple_obtains_returns_dict(self, nl):
+        result = _execute_squall_program(
+            nl,
+            "obtain every Person that plays.\n"
+            "obtain every Person.",
+        )
+        assert isinstance(result, dict)
+        assert "obtain_0" in result
+        assert "obtain_1" in result
+
+    def test_single_obtain_formatting_has_columns(self, nl):
+        result = _execute_squall_program(
+            nl, "obtain every Person that plays."
+        )
+        output = _format_result(result)
+        from neurolang.utils.relational_algebra_set.pandas import (
+            NamedRelationalAlgebraFrozenSet,
+        )
+        assert isinstance(result, NamedRelationalAlgebraFrozenSet)
+        # Named columns should appear in the table output
+        assert any(
+            c in output for c in result.columns
+        ), f"Column names {result.columns} not found in output:\n{output}"
+
+    def test_squall_format_result_none(self, nl):
+        result = _execute_squall_program(
+            nl, "define as Active every person that plays."
+        )
+        assert _format_result(result) == ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,11 @@ dependencies = [
     "rdflib>=6.0.0",
     "sqlalchemy>=1.4",
     "siibra>=1.0.1a15",
+    "pyyaml>=6.0",
 ]
+
+[project.scripts]
+neurolang-query = "neurolang.utils.cli:main"
 
 [project.urls]
 Homepage = "https://neurolang.github.io"


### PR DESCRIPTION
Adds a contains(R, (I, J, K)) Datalog operator that decomposes a brain region into individual voxel coordinates.

Includes new engine registry infrastructure (YAML-driven engine definitions, template loading, CLI) required by the destroy operator demo.

Key changes:
- Engine registry with YAML-driven engine building (templates, atlases, relations, datalog init)
- tuple_literal grammar rule in standard_syntax.py for (a, b, c) syntax
- ExplicitVBR.__contains__ for voxel membership checks
- contains builtin registered in QueryBuilderDatalog frontend
- PandasSet.explode handles Region columns by converting voxel arrays to iterable tuples
- precompute YAML option for eager IDB materialisation via chase
- Destrieux engine: precomputed destrieux_voxel predicate (95K rows)
- Atlas fetch kwarg filtering (_ATLAS_FETCH_SKIP)
- _builtin_startswith annotation fix for Python 3.12 compat

Testing: 145 tests pass (region, frontend, CLI, RA)