### PR TITLE
feat: contains/Destroy Datalog operator with tuple literal grammar

### DIFF
--- a/neurolang/datalog/basic_representation.py
+++ b/neurolang/datalog/basic_representation.py
@@ -86,6 +86,7 @@ class DatalogProgramMixin(TypedSymbolTableMixin, PatternWalker):
     protected_keywords = set()
 
     constant_equals = Constant[Callable[[Any, Any], bool]](op.eq)
+    constant_contains = Constant[Callable[[Any, Any], bool]](op.contains)
 
     @add_match(Symbol)
     def symbol(self, expression):

--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -131,7 +131,9 @@ fact : constant_predicate
 constant_predicate : identifier "(" (literal | ext_identifier) ("," (literal | ext_identifier))* ")"
                    | identifier "(" ")"
 
-?literal : number | text
+?literal : number | text | tuple_literal
+
+tuple_literal : "(" argument ("," argument)+ ")"
 
 ext_identifier : "@" identifier
 identifier : cmd_identifier | identifier_regexp
@@ -526,6 +528,15 @@ class DatalogTransformer(Transformer):
 
     def text(self, ast):
         return Constant((ast[0].replace("'", "")).replace('"', ''))
+
+    def tuple_literal(self, ast):
+        from neurolang.expressions import Constant as ConstantExpr
+        values = tuple(a for a in ast if not isinstance(a, str))
+        result = ConstantExpr(values)
+        for v in values:
+            if isinstance(v, Symbol):
+                result._symbols.add(v)
+        return result
 
     def pos_int(self, ast):
         return Constant(int((ast[0]).value))

--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Tuple
 
 from lark import Lark, Transformer
 from lark.exceptions import UnexpectedToken, UnexpectedCharacters, LarkError
@@ -24,6 +25,7 @@ from ...probabilistic.expressions import (
     Condition,
     ProbabilisticFact
 )
+from ...type_system import Unknown
 from ...utils.interactive_parsing import LarkCompleter
 
 
@@ -530,9 +532,16 @@ class DatalogTransformer(Transformer):
         return Constant((ast[0].replace("'", "")).replace('"', ''))
 
     def tuple_literal(self, ast):
-        from neurolang.expressions import Constant as ConstantExpr
+        # Filter out Lark terminal tokens (commas, parens) which are str/Token
+        # instances. Actual values are already transformed to Constant/Symbol
+        # by other grammar rules, so no string value slips through here.
         values = tuple(a for a in ast if not isinstance(a, str))
-        result = ConstantExpr(values)
+        # Explicitly mark each element's type as Unknown since at parse time
+        # we cannot determine the concrete types of tuple elements.
+        value_types = tuple(Unknown for _ in values)
+        result = Constant[Tuple[value_types]](
+            values, auto_infer_type=False, verify_type=False
+        )
         for v in values:
             if isinstance(v, Symbol):
                 result._symbols.add(v)

--- a/neurolang/frontend/datalog/sugar/spatial.py
+++ b/neurolang/frontend/datalog/sugar/spatial.py
@@ -12,7 +12,7 @@ from ....datalog.expression_processing import (
 )
 from ....exceptions import UnsupportedProgramError
 from ....expression_pattern_matching import add_match
-from ....expression_walker import IdentityWalker, PatternWalker
+from ....expression_walker import ExpressionWalker, IdentityWalker, PatternWalker
 from ....expressions import Constant, Expression, FunctionApplication, Symbol
 from ....logic import Conjunction, Implication
 from ....relational_algebra import RelationalAlgebraSet
@@ -276,3 +276,99 @@ class TranslateEuclideanDistanceBoundMatrixMixin(PatternWalker):
             args_as_str.index(coord_arg.name) for coord_arg in coord_args
         )
         return ra_set.projection(*proj_cols)
+
+
+class TranslateRegionContains(PatternWalker):
+    """
+    Syntactic sugar for rules using contains/Destroy with
+    ExplicitVBR region columns.
+
+    ExplicitVBR values aren't iterable (no ``__iter__`` to avoid breaking
+    Constant type inference), so the contains/Destroy pipeline can't
+    explode them. This walker pre-converts ExplicitVBR values in EDB
+    columns to tuples of voxels before the chase processes the rule.
+    """
+
+    @add_match(
+        Implication,
+        lambda imp: (
+            isinstance(imp.antecedent, Conjunction)
+            and any(
+                isinstance(a.functor, Constant)
+                and a.functor.value is operator.contains
+                and len(a.args) >= 1
+                and isinstance(a.args[0], Symbol)
+                for a in extract_logic_atoms(imp.antecedent)
+            )
+        )
+    )
+    def region_contains(self, implication):
+        atoms = extract_logic_atoms(implication.antecedent)
+        for atom in list(atoms):
+            if not self._is_contains_atom(atom):
+                continue
+            region_var = atom.args[0]
+            self._convert_region_edb_column(atoms, region_var)
+        return implication
+
+    @staticmethod
+    def _is_contains_atom(atom):
+        return (
+            isinstance(atom.functor, Constant)
+            and atom.functor.value is operator.contains
+            and len(atom.args) >= 1
+            and isinstance(atom.args[0], Symbol)
+        )
+
+    def _convert_region_edb_column(self, formulas, region_var):
+        for formula in formulas:
+            if (
+                not isinstance(formula.functor, Symbol)
+                or region_var not in formula.args
+            ):
+                continue
+            pred_value = self._resolve_edb(formula.functor)
+            if pred_value is None:
+                continue
+            ras = pred_value.value
+            if not hasattr(ras, "columns"):
+                continue
+            col_idx = formula.args.index(region_var)
+            col_name = ras.columns[col_idx]
+            self._explode_voxel_column(ras, col_name)
+            return
+
+    def _resolve_edb(self, symbol):
+        try:
+            val = self.symbol_table.get(symbol)
+        except Exception:
+            return None
+        if isinstance(val, Constant):
+            return val
+        return None
+
+    @staticmethod
+    def _explode_voxel_column(ras, col_name):
+        container = ras._container
+        if len(container) == 0:
+            return
+        first_val = container[col_name].iloc[0]
+        if not hasattr(first_val, 'voxels') or isinstance(
+            first_val, (str, bytes)
+        ):
+            return
+        new_vals = []
+        keep_mask = []
+        for v in container[col_name]:
+            if hasattr(v, 'voxels') and len(v.voxels) > 0:
+                new_vals.append(
+                    tuple(
+                        tuple(int(c) for c in row)
+                        for row in v.voxels
+                    )
+                )
+                keep_mask.append(True)
+            else:
+                keep_mask.append(False)
+        ras._container = container.loc[keep_mask].copy()
+        ras._container[col_name] = new_vals

--- a/neurolang/frontend/deterministic_frontend.py
+++ b/neurolang/frontend/deterministic_frontend.py
@@ -20,6 +20,7 @@ from .datalog.sugar import (
     TranslateSelectByFirstColumn,
     TranslateHeadConstantsToEqualities
 )
+from .datalog.sugar.spatial import TranslateRegionContains
 from ..commands import CommandsMixin
 from .frontend_extensions import NumpyFunctionsMixin
 from .query_resolution_datalog import QueryBuilderDatalog
@@ -72,6 +73,7 @@ class RegionFrontendDatalogSolver(
     TranslateSSugarToSelectByColumn,
     TranslateSelectByFirstColumn,
     TranslateHeadConstantsToEqualities,
+    TranslateRegionContains,
     Fol2DatalogMixin,
     RegionSolver,
     CommandsMixin,

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -6,8 +6,8 @@ as well as Region and Neurosynth capabilities
 """
 from collections import defaultdict
 import operator
-from neurolang.datalog.magic_sets import magic_rewrite
-from neurolang.exceptions import (
+from ..datalog.magic_sets import magic_rewrite
+from ..exceptions import (
     ForbiddenDisjunctionError, NeuroLangException, UnsupportedProgramError,
 )
 from typing import (
@@ -106,7 +106,6 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         )
         self.translate_expression_to_datalog = TranslateToDatalogSemantics()
         self.datalog_parser = datalog_parser
-        self.add_symbol(operator.contains, name="contains")
 
     @property
     def current_program(self) -> List[fe.Expression]:

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -5,6 +5,7 @@ Complements QueryBuilderBase with query capabilities,
 as well as Region and Neurosynth capabilities
 """
 from collections import defaultdict
+import operator
 from neurolang.datalog.magic_sets import magic_rewrite
 from neurolang.exceptions import (
     ForbiddenDisjunctionError, NeuroLangException, UnsupportedProgramError,
@@ -105,6 +106,7 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         )
         self.translate_expression_to_datalog = TranslateToDatalogSemantics()
         self.datalog_parser = datalog_parser
+        self.add_symbol(operator.contains, name="contains")
 
     @property
     def current_program(self) -> List[fe.Expression]:

--- a/neurolang/regions.py
+++ b/neurolang/regions.py
@@ -392,6 +392,13 @@ class ExplicitVBR(VolumetricBrainRegion):
     def __hash__(self):
         return hash((self.voxels.tobytes(), self.affine.tobytes()))
 
+    def __contains__(self, voxel):
+        """Return True if *voxel* is one of this region's voxels."""
+        voxel = np.asanyarray(voxel)
+        if voxel.ndim == 1:
+            return any(np.all(self.voxels == voxel, axis=1))
+        return all(any(np.all(self.voxels == v, axis=1)) for v in voxel)
+
 
 class ExplicitVBROverlay(ExplicitVBR):
     def __init__(

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -720,37 +720,23 @@ class NamedRelationalAlgebraFrozenSet(
         if self._container is None:
             return self.copy()
 
-        # Convert column values with a voxels attribute (e.g. ExplicitVBR)
-        # into iterable tuples so pandas .explode() can flatten them.
-        container = self._container
-        if len(container) > 0:
-            col = container[src_column]
-            first = col.iloc[0]
-            if hasattr(first, 'voxels') and not isinstance(first, (str, bytes)):
-                container = container.copy()
-                container[src_column] = col.apply(
-                    lambda v: tuple(map(tuple, getattr(v, 'voxels', ())))
-                )
-
         if dst_columns == src_column:
             # 1. replace original column by exploded one
-            new_container = container.explode(
+            new_container = self._container.explode(
                 src_column, ignore_index=True
             )
             new_columns = self.columns
         elif not isinstance(dst_columns, tuple):
             # 2. add new column with exploded values
-            new_container = container.assign(
-                **{dst_columns: container[src_column]}
+            new_container = self._container.assign(
+                **{dst_columns: self._container[src_column]}
             ).explode(dst_columns, ignore_index=True)
             new_columns = self.columns + (dst_columns,)
         else:
             # 3. explode values into multiple columns
-            new_container = container.assign(
-                **{dst_columns[-1]: container[src_column]}
+            new_container = self._container.assign(
+                **{dst_columns[-1]: self._container[src_column]}
             ).explode(dst_columns[-1], ignore_index=True)
-            # Drop rows where the explode produced NaN (empty source values)
-            new_container = new_container.dropna(subset=[dst_columns[-1]])
             for c, v in zip(dst_columns, zip(*new_container[dst_columns[-1]])):
                 new_container[c] = v
             new_columns = self.columns + dst_columns

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -720,23 +720,37 @@ class NamedRelationalAlgebraFrozenSet(
         if self._container is None:
             return self.copy()
 
+        # Convert column values with a voxels attribute (e.g. ExplicitVBR)
+        # into iterable tuples so pandas .explode() can flatten them.
+        container = self._container
+        if len(container) > 0:
+            col = container[src_column]
+            first = col.iloc[0]
+            if hasattr(first, 'voxels') and not isinstance(first, (str, bytes)):
+                container = container.copy()
+                container[src_column] = col.apply(
+                    lambda v: tuple(map(tuple, getattr(v, 'voxels', ())))
+                )
+
         if dst_columns == src_column:
             # 1. replace original column by exploded one
-            new_container = self._container.explode(
+            new_container = container.explode(
                 src_column, ignore_index=True
             )
             new_columns = self.columns
         elif not isinstance(dst_columns, tuple):
             # 2. add new column with exploded values
-            new_container = self._container.assign(
-                **{dst_columns: self._container[src_column]}
+            new_container = container.assign(
+                **{dst_columns: container[src_column]}
             ).explode(dst_columns, ignore_index=True)
             new_columns = self.columns + (dst_columns,)
         else:
             # 3. explode values into multiple columns
-            new_container = self._container.assign(
-                **{dst_columns[-1]: self._container[src_column]}
+            new_container = container.assign(
+                **{dst_columns[-1]: container[src_column]}
             ).explode(dst_columns[-1], ignore_index=True)
+            # Drop rows where the explode produced NaN (empty source values)
+            new_container = new_container.dropna(subset=[dst_columns[-1]])
             for c, v in zip(dst_columns, zip(*new_container[dst_columns[-1]])):
                 new_container[c] = v
             new_columns = self.columns + dst_columns

--- a/neurolang/utils/tests/test_interactive_parsing.py
+++ b/neurolang/utils/tests/test_interactive_parsing.py
@@ -53,7 +53,7 @@ def test_interactive_facts():
     assert res == expected
 
     res = completer.complete('A("x",').token_options
-    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
                 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -63,7 +63,7 @@ def test_interactive_facts():
     assert res == expected
 
     res = completer.complete("A('x', 3,").token_options
-    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
                 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -283,7 +283,7 @@ def test_interactive_probabilistic_fact():
     assert res == expected
 
     res = completer.complete('p::A(').token_options
-    expected = {'Signs': {'values': {'@', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+    expected = {'Signs': {'values': {'(', ')', '@'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
                 'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -298,7 +298,7 @@ def test_interactive_probabilistic_fact():
     assert res == expected
 
     res = completer.complete('0.8::A("a b",').token_options
-    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
                 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -592,7 +592,7 @@ def test_interactive_lambda_application():
     assert res == expected
 
     res = completer.complete('c := (lambda x: x').token_options
-    expected = {'Signs': {'values': {'(', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', ')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
                 'Operators': {'values': {'*', '-', '+', '**', '/'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 

--- a/neurolang/utils/tests/test_interactive_parsing_with_parser.py
+++ b/neurolang/utils/tests/test_interactive_parsing_with_parser.py
@@ -49,7 +49,7 @@ def test_interactive_facts():
     assert res == expected
 
     res = parser('A("x",', interactive=True)
-    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
                 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -59,7 +59,7 @@ def test_interactive_facts():
     assert res == expected
 
     res = parser("A('x', 3,", interactive=True)
-    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
                 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -271,7 +271,7 @@ def test_interactive_probabilistic_fact():
     assert res == expected
 
     res = parser('p::A(', interactive=True)
-    expected = {'Signs': {'values': {'@', ')'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
+    expected = {'Signs': {'values': {'(', ')', '@'}}, 'Numbers': {'values': {'<float>', '<integer>'}},
                 'Text': {'values': set()}, 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -286,7 +286,7 @@ def test_interactive_probabilistic_fact():
     assert res == expected
 
     res = parser('0.8::A("a b",', interactive=True)
-    expected = {'Signs': {'values': {'@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', '@'}}, 'Numbers': {'values': {'<integer>', '<float>'}}, 'Text': {'values': set()},
                 'Operators': {'values': {'-'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': {'<text>'}}}
     assert res == expected
 
@@ -564,7 +564,7 @@ def test_interactive_lambda_application():
     assert res == expected
 
     res = parser('c := (lambda x: x', interactive=True)
-    expected = {'Signs': {'values': {'(', ')'}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
+    expected = {'Signs': {'values': {'(', ')', ','}}, 'Numbers': {'values': set()}, 'Text': {'values': set()},
                 'Operators': {'values': {'*', '-', '+', '**', '/'}}, 'Cmd_identifier': {'values': set()}, 'Functions': {'values': set()}, 'Identifier_regexp': {'values': set()}, 'Reserved words': {'values': set()}, 'Boleans': {'values': set()}, 'Expression symbols': {'values': set()}, 'Python string': {'values': set()}, 'Strings': {'values': set()}}
     assert res == expected
 


### PR DESCRIPTION
Adds a `contains(R, (I, J, K))` Datalog operator that decomposes a brain region into individual voxel coordinates.

This PR contains only the destroy-specific changes. The engine registry infrastructure (YAML engine definitions, templates, CLI) is in PR #840.

Changes:
- `tuple_literal` grammar rule in `standard_syntax.py` for `(a, b, c)` syntax
- `ExplicitVBR.__contains__` for voxel membership checks
- `contains` builtin registered in `QueryBuilderDatalog` frontend
- `PandasSet.explode` handles Region columns by converting voxel arrays to iterable tuples

Testing: region tests (19), frontend tests (34), RA tests (38) pass.