### PR TITLE
feat: add TypeResolutionMixin for predicate-based variable type inference

### DIFF
--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -90,6 +90,7 @@ class ParametricTypeClassMeta(type):
     @lru_cache(maxsize=None)
     def __getitem__(self, type_):
         d = dict(self.__dict__)
+        d['_nl_class_type'] = type_
         d['type'] = type_
         d['__generic_class__'] = self
         d['__no_explicit_type__'] = False
@@ -108,11 +109,11 @@ class ParametricTypeClassMeta(type):
 
     def __repr__(self):
         r = self.__name__
-        if hasattr(self, 'type'):
-            if isinstance(self.type, type):
-                c = self.type.__name__
+        if hasattr(self, '_nl_class_type'):
+            if isinstance(self._nl_class_type, type):
+                c = self._nl_class_type.__name__
             else:
-                c = repr(self.type)
+                c = repr(self._nl_class_type)
             r += '[{}]'.format(c)
         return r
 
@@ -133,7 +134,9 @@ class ParametricTypeClassMeta(type):
             return issubclass(
                 other.__generic_class__,
                 self.__generic_class__
-            ) and is_leq_informative(other.type, self.type)
+            ) and is_leq_informative(
+                other._nl_class_type, self._nl_class_type
+            )
         else:
             return issubclass(
                 other.__generic_class__, self
@@ -182,11 +185,11 @@ class ExpressionMeta(ParametricTypeClassMeta):
     """
 
     def __new__(cls, *args, **kwargs):
-        __no_explicit_type__ = 'type' not in args[2]
+        __no_explicit_type__ = '_nl_class_type' not in args[2]
         obj = super().__new__(cls, *args, **kwargs)
         obj.__no_explicit_type__ = __no_explicit_type__
         if obj.__no_explicit_type__:
-            obj.type = typing.Any
+            obj._nl_class_type = typing.Any
         orig_init = obj.__init__
         obj.__children__ = [
             name for name, parameter
@@ -257,6 +260,36 @@ class Expression(metaclass=ExpressionMeta):
         '__code__', '__defaults__', '__kwdefaults__', '__no_type_check__'
     )
 
+    @property
+    def type(self):
+        """Get the expression's type.
+
+        For parameterized classes (e.g., FunctionApplication[bool]), the
+        type is stored as a class attribute under _nl_class_type. For
+        non-parameterized classes, it is stored as an instance attribute
+        under _type, defaulting to Unknown.  Class-level access (e.g.,
+        PM.type for a class PM that inherits from PatternMatcher[int])
+        also works by reading _nl_class_type from the class hierarchy.
+
+        This property avoids instance-attribute shadowing: calling
+        self.type = X in __init__ stores via the setter under _type,
+        and change_type (which changes __class__ to a parameterized class)
+        makes the type available from the class attribute — no need to
+        pop anything from __dict__.
+        """
+        if isinstance(self, ParametricTypeClassMeta):
+            return getattr(self, '_nl_class_type', Unknown)
+        cls = self.__class__
+        if cls.__parameterized__:
+            cls_type = cls._nl_class_type
+            if cls_type is not Unknown and cls_type is not typing.Any:
+                return cls_type
+        return self.__dict__.get('_type', Unknown)
+
+    @type.setter
+    def type(self, value):
+        self.__dict__['_type'] = value
+
     def __init__(self, *args, **kwargs):
         raise TypeError("Expression can not be instantiated")
 
@@ -309,7 +342,6 @@ class Expression(metaclass=ExpressionMeta):
 
     def change_type(self, type_):
         self.__class__ = self.__class__[type_]
-        self.__dict__.pop("type", None)
 
     def cast(self, type_):
         if type_ == self.type:
@@ -486,8 +518,8 @@ class Symbol(NonConstant):
         if not hasattr(Symbol, '_fresh_generator_'):
             Symbol._fresh_generator_ = Symbol._fresh_generator()
         new_symbol = cls(next(Symbol._fresh_generator_))
-        if cls.type is not typing.Any:
-            new_symbol = new_symbol.cast(cls.type)
+        if cls._nl_class_type is not typing.Any:
+            new_symbol = new_symbol.cast(cls._nl_class_type)
         new_symbol.is_fresh = True
         return new_symbol
 
@@ -618,7 +650,6 @@ class Constant(Expression):
 
     def change_type(self, type_):
         self.__class__ = self.__class__[type_]
-        self.__dict__.pop("type", None)
         if not self.__verify_type__(self.value, self.type):
             raise NeuroLangTypeException(
                 "The value %s does not correspond to the type %s" %

--- a/neurolang/expressions.py
+++ b/neurolang/expressions.py
@@ -309,6 +309,7 @@ class Expression(metaclass=ExpressionMeta):
 
     def change_type(self, type_):
         self.__class__ = self.__class__[type_]
+        self.__dict__.pop("type", None)
 
     def cast(self, type_):
         if type_ == self.type:
@@ -617,6 +618,7 @@ class Constant(Expression):
 
     def change_type(self, type_):
         self.__class__ = self.__class__[type_]
+        self.__dict__.pop("type", None)
         if not self.__verify_type__(self.value, self.type):
             raise NeuroLangTypeException(
                 "The value %s does not correspond to the type %s" %

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -6,7 +6,7 @@ propagated to variable symbols in Datalog rules, and that rules with
 no resolvable type information are passed through unchanged.
 """
 
-from typing import Callable
+from typing import AbstractSet, Callable
 
 import pytest
 
@@ -57,6 +57,9 @@ class TestTypeResolutionMixin:
 
         assert x.type is int
         assert y.type is float
+        # Predicate symbol type propagated from EDB entry
+        entry = program.symbol_table[R]
+        assert entry.type is not Unknown
 
     def test_conjunctive_body_resolves_variables(self, solver):
         mixin, program = solver
@@ -76,6 +79,8 @@ class TestTypeResolutionMixin:
 
         assert x.type is int
         assert y.type is str
+        entry = program.symbol_table[R]
+        assert entry.type is not Unknown
 
     def test_rule_passes_through_when_no_types_available(self, solver):
         mixin, _ = solver
@@ -109,6 +114,8 @@ class TestTypeResolutionMixin:
 
         assert x.type is int
         assert y.type is Unknown
+        entry = program.symbol_table[R]
+        assert entry.type is not Unknown
 
     def test_builtin_callable_body_resolves_arg_types(self, solver):
         mixin, program = solver
@@ -143,3 +150,49 @@ class TestTypeResolutionMixin:
         mixin.walk(rule)
 
         assert x.type is int
+        entry = program.symbol_table[R]
+        assert entry.type is not Unknown
+
+
+class TestTypeResolutionIntegration:
+    """Integration tests using the full NeurolangDL solver stack."""
+
+    def test_edb_propagates_types_through_full_solver(self):
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(10, "hello"), (20, "world")], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x, e.y]
+            res = nl.query((e.x, e.y), e.Q[e.x, e.y])
+
+        assert len(res) == 2
+        assert set(res) == {(10, "hello"), (20, "world")}
+
+    def test_partial_type_resolution_with_mixed_predicates(self):
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 2.5), (3, 4.5)], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x, e.y]
+            res = nl.query((e.x, e.y), e.Q[e.x, e.y])
+
+        assert len(res) == 2
+        assert set(res) == {(1, 2.5), (3, 4.5)}
+
+    def test_conjunctive_body_rule_in_full_solver(self):
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, "a"), (2, "b")], name="R")
+        nl.add_tuple_set([(1, 10), (2, 20)], name="S")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y, e.z] = e.R[e.x, e.y] & e.S[e.x, e.z]
+            res = nl.query((e.x, e.y, e.z), e.Q[e.x, e.y, e.z])
+
+        assert len(res) == 2
+        assert set(res) == {(1, "a", 10), (2, "b", 20)}

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -1,0 +1,163 @@
+"""Tests for TypeResolutionMixin.
+
+Validates that types from EDB predicates and builtin functions are
+propagated to variable symbols in Datalog rules, and that rules with
+no resolvable type information are passed through unchanged.
+"""
+
+from typing import AbstractSet, Callable, Tuple
+
+import pytest
+
+from .... import expressions as ir
+from ....datalog.basic_representation import DatalogProgram
+from ....datalog.expressions import Implication
+from ....datalog.wrapped_collections import WrappedRelationalAlgebraFrozenSet
+from ....expressions import Constant, FunctionApplication, Symbol
+from ....frontend.type_resolution import TypeResolutionMixin
+from ....logic import Conjunction
+from ....type_system import Unknown
+from ....utils import NamedRelationalAlgebraFrozenSet
+
+def _dummy_fn(a: int, b: float) -> bool:
+    return a > b
+
+
+@pytest.fixture
+def solver():
+    """Create a TypeResolutionMixin wired to a fresh DatalogProgram's
+    symbol table, with no EDB predicates loaded."""
+    program = DatalogProgram()
+    mixin = TypeResolutionMixin()
+    mixin.symbol_table = program.symbol_table
+    return mixin, program
+
+
+def _typed_symbol(name, type_):
+    """Helper to create a Symbol with a specific type annotation."""
+    s = Symbol(name)
+    s.type = type_
+    return s
+
+
+class TestTypeResolutionMixin:
+    def test_edb_predicate_body_resolves_variable_types(self, solver):
+        """A single EDB predicate in the body provides column types
+        for the rule variables."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(
+            R, [(1, 2.5), (3, 4.5)]
+        )
+
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        assert x.type is Unknown
+        assert y.type is Unknown
+
+        rule = Implication(Q(x, y), R(x, y))
+        mixin.walk(rule)
+
+        assert x.type is not Unknown
+        assert y.type is not Unknown
+        assert x.type is int or issubclass(x.type, int)
+        assert y.type is float or issubclass(y.type, float)
+
+    def test_conjunctive_body_resolves_variables(self, solver):
+        """When the body is a Conjunction with an EDB predicate,
+        variable types are still resolved."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(
+            R, [(10, "hello"), (20, "world")]
+        )
+
+        x = Symbol("x")
+        y = Symbol("y")
+        t = Symbol("t")
+        Q = Symbol("Q")
+
+        conj = Conjunction((R(x, y),))
+        rule = Implication(Q(x, y), conj)
+        mixin.walk(rule)
+
+        assert x.type is not Unknown
+        assert y.type is not Unknown
+
+    def test_skipped_when_no_types_available(self, solver):
+        """When no body predicate has a known type in the symbol table,
+        the implication is returned unchanged."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), R(x))
+        result = mixin.walk(rule)
+
+        assert x.type is Unknown
+        assert result is rule
+
+    def test_partial_resolution_mixed_predicates(self, solver):
+        """When some body predicates have known types and others don't,
+        variables that appear in the typed predicate get their types
+        resolved."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1,)])
+
+        S = Symbol("S")
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        conj = Conjunction((R(x), S(y)))
+        rule = Implication(Q(x, y), conj)
+        mixin.walk(rule)
+
+        assert x.type is not Unknown
+        assert y.type is Unknown
+
+    def test_builtin_callable_body_resolves_arg_types(self, solver):
+        """A body predicate whose functor is a builtin Callable
+        provides parameter types."""
+        mixin, program = solver
+
+        fn_sym = Symbol("fn")
+        program.symbol_table[fn_sym] = Constant[Callable[[int, float], bool]](
+            _dummy_fn
+        )
+
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x, y), fn_sym(x, y))
+        mixin.walk(rule)
+
+        assert x.type is not Unknown
+        assert y.type is not Unknown
+
+    def test_constant_arguments_do_not_block_typed_predicates(self, solver):
+        """Constant arguments in body predicates don't block type
+        inference from the predicate's column types."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(
+            R, [(1, 2)]
+        )
+
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), R(x, Constant[int](3)))
+        mixin.walk(rule)
+
+        assert x.type is not Unknown

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -12,6 +12,7 @@ import pytest
 
 from ....datalog.basic_representation import DatalogProgram
 from ....datalog.expressions import Implication
+from ....datalog.magic_sets import AdornedSymbol
 from ....datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ....expressions import Constant, Symbol
 from ....frontend.type_resolution import TypeResolutionMixin
@@ -414,6 +415,105 @@ class TestTypeResolutionMixin:
         assert y.type is float
         assert rule.consequent.type is bool
 
+    # ------------------------------------------------------------------
+    # IDB-to-IDB type propagation
+    # ------------------------------------------------------------------
+
+    def test_idb_predicate_type_propagation(self, solver):
+        """Types propagate from an IDB predicate's resolved head args
+        to body variables in a dependent rule."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(
+            R, [(10, "hello")]
+        )
+
+        # Define Q in terms of R — the type resolver processes this
+        # and DatalogProgram.statement_intensional registers Q in
+        # the symbol table as a Union of Implications.
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+        rule_q = Implication(Q(x, y), R(x, y))
+        mixin.walk(rule_q)
+
+        assert x.type is int
+        assert y.type is str
+
+        # Now define P in terms of Q — Q's head args have their types
+        # set after rule_q was processed, so the IDB entry for Q
+        # carries type information.
+        a = Symbol("a")
+        b = Symbol("b")
+        P = Symbol("P")
+        rule_p = Implication(P(a, b), Q(a, b))
+        mixin.walk(rule_p)
+
+        assert a.type is int
+        assert b.type is str
+
+    def test_warning_for_missing_symbol_table_entry(self, solver):
+        """A warning is issued when a body predicate has no entry
+        in the symbol table."""
+        import warnings
+
+        mixin, _ = solver
+
+        Z = Symbol("Z")
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), Z(x))
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mixin.walk(rule)
+
+        assert any(
+            "no entry" in str(warning.message).lower()
+            for warning in w
+        ), "Expected a warning about missing symbol table entry"
+
+    # ------------------------------------------------------------------
+    # Magic-sets AdornedSymbol guards
+    # ------------------------------------------------------------------
+
+    def test_adorned_symbol_skips_type_resolution(self, solver):
+        """When the head functor is an AdornedSymbol (as produced by
+        magic-sets rewriting), type resolution is skipped entirely
+        — no warnings for missing body predicates, no type
+        propagation to body Symbols, and the head is still marked
+        as bool to prevent re-matching."""
+        import warnings
+
+        mixin, _ = solver
+
+        Z = Symbol("Z")
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        # AdornedSymbol mimics what the magic-sets layer produces:
+        # an adorned copy of the original rule's head functor.
+        q_adorned = AdornedSymbol(Q, "bf", 0)
+        rule = Implication(q_adorned(x), Z(x))
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mixin.walk(rule)
+
+        # No warning despite Z having no symbol-table entry
+        assert len(w) == 0, (
+            f"Expected no warnings for adorned rules, "
+            f"got: {[str(msg.message) for msg in w]}"
+        )
+
+        # Body symbols were NOT resolved
+        assert x.type is Unknown, "Body symbols should not be resolved"
+
+        # Head FA type is set to bool (prevents re-matching on re-entry)
+        assert rule.consequent.type is bool
+
 
 class TestTypeResolutionIntegration:
     """
@@ -540,7 +640,31 @@ class TestTypeResolutionIntegration:
         with nl.scope as e:
             e.Q[e.x, e.y] = e.R[e.x, e.y]
             impl = self._get_stored_implication(nl)
-            assert impl.consequent.type is bool
+        assert impl.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # IDB-to-IDB type propagation via full solver
+    # ------------------------------------------------------------------
+
+    def test_idb_type_propagation_integration(self):
+        """Types from an IDB predicate propagate to dependent rules
+        through the full solver stack."""
+        from ....frontend.deterministic_frontend import NeurolangDL
+        from .... import expressions as ir
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(10, "hello")], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x, e.y]
+            e.P[e.a, e.b] = e.Q[e.a, e.b]
+
+            idb = nl.program_ir.intensional_database()
+            p_union = idb[ir.Symbol("P")]
+            p_impl = p_union.formulas[0]
+            atoms = self._get_body_atoms(p_impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[0].args[1].type is str
 
     def test_constant_argument_body_atom_types(self):
         """EDB with constant argument: variable arg still resolved."""

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -453,9 +453,14 @@ class TestTypeResolutionMixin:
         assert a.type is int
         assert b.type is str
 
+    # ------------------------------------------------------------------
+    # Warning behavior for missing symbol table entries
+    # ------------------------------------------------------------------
+
     def test_warning_for_missing_symbol_table_entry(self, solver):
         """A warning is issued when a body predicate has no entry
-        in the symbol table."""
+        in the symbol table, with the exact predicate name in the
+        message."""
         import warnings
 
         mixin, _ = solver
@@ -470,10 +475,148 @@ class TestTypeResolutionMixin:
             warnings.simplefilter("always")
             mixin.walk(rule)
 
-        assert any(
-            "no entry" in str(warning.message).lower()
-            for warning in w
-        ), "Expected a warning about missing symbol table entry"
+        assert len(w) == 1, (
+            f"Expected exactly 1 warning, got {len(w)}: "
+            f"{[str(msg.message) for msg in w]}"
+        )
+        assert issubclass(w[0].category, UserWarning)
+        msg = str(w[0].message)
+        assert "Z" in msg, f"Warning should mention predicate name Z: {msg}"
+        assert "no entry" in msg.lower(), (
+            f"Warning should explain the predicate has no entry: {msg}"
+        )
+
+    def test_warning_for_multiple_missing_predicates(self, solver):
+        """Separate warnings are issued for each body predicate
+        missing from the symbol table."""
+        import warnings
+
+        mixin, _ = solver
+
+        Z = Symbol("Z")
+        W = Symbol("W")
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        from ....datalog.expressions import Conjunction
+        body = Conjunction((Z(x), W(y)))
+        rule = Implication(Q(x, y), body)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mixin.walk(rule)
+
+        assert len(w) == 2, (
+            f"Expected 2 warnings (one per missing predicate), "
+            f"got {len(w)}: {[str(msg.message) for msg in w]}"
+        )
+        predicate_names = set()
+        for warning in w:
+            predicate_names.update(
+                word for word in str(warning.message).split()
+                if word in {"Z", "W"}
+            )
+        assert predicate_names == {"Z", "W"}, (
+            f"Warnings should mention both Z and W, "
+            f"got names: {predicate_names}"
+        )
+
+    def test_partial_resolution_with_warning(self, solver):
+        """When one body predicate is in the symbol table and another
+        is missing, a warning fires for the missing predicate but types
+        are still resolved from the known predicate."""
+        import warnings
+
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1, 2.5)])
+
+        Z = Symbol("Z")
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        from ....datalog.expressions import Conjunction
+        body = Conjunction((R(x, y), Z(y)))
+        rule = Implication(Q(x, y), body)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mixin.walk(rule)
+
+        # Warning for Z but not for R
+        assert len(w) == 1, (
+            f"Expected 1 warning (for Z only), "
+            f"got {len(w)}: {[str(msg.message) for msg in w]}"
+        )
+        assert "Z" in str(w[0].message)
+
+        # Types from the known EDB predicate still resolved
+        assert x.type is int
+        assert y.type is float
+
+    def test_no_warning_for_edb_predicate(self, solver):
+        """No warning when a body predicate's functor is registered
+        as an EDB in the symbol table."""
+        import warnings
+
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1, 2.5)])
+
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x, y), R(x, y))
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mixin.walk(rule)
+
+        warnings_for_R = [
+            msg for msg in w
+            if "R" in str(msg.message)
+        ]
+        assert len(warnings_for_R) == 0, (
+            f"Expected no warnings for EDB predicate R, "
+            f"got: {[str(msg.message) for msg in warnings_for_R]}"
+        )
+
+    def test_no_warning_for_non_symbol_functor(self, solver):
+        """No warning when a body atom uses a non-Symbol functor
+        (e.g. a Constant functor from an equality predicate)
+        — the code skips these without warning."""
+        import warnings
+
+        from ....expressions import Constant, FunctionApplication
+
+        mixin, _ = solver
+
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        # A body atom with a Constant functor (like an equality
+        # predicate eq(x, 5) where the functor is the operator).
+        # The code skips non-Symbol functors without warning.
+        eq_body = FunctionApplication(
+            Constant(Callable[..., bool])(lambda a: a == 5),
+            (x,),
+        )
+
+        rule = Implication(Q(x), eq_body)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mixin.walk(rule)
+
+        assert len(w) == 0, (
+            f"Expected no warnings for Constant-functor body atom, "
+            f"got: {[str(msg.message) for msg in w]}"
+        )
 
     # ------------------------------------------------------------------
     # Magic-sets AdornedSymbol guards

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -155,9 +155,28 @@ class TestTypeResolutionMixin:
 
 
 class TestTypeResolutionIntegration:
-    """Integration tests using the full NeurolangDL solver stack."""
+    """
+    Integration tests using the full solver stack.
 
-    def test_edb_propagates_types_through_full_solver(self):
+    Type assertions inspect the stored Implication's body atoms directly
+    (inside the scope block before scope exit discards symbols).
+    """
+
+    def _get_body_atoms(self, impl):
+        from ....datalog.expression_processing import extract_logic_atoms
+        return list(extract_logic_atoms(impl.antecedent))
+
+    def _get_stored_implication(self, nl):
+        """Retrieve the single Implication for head symbol Q from the
+        program's IDB while still inside the active scope."""
+        from .... import expressions as ir
+        idb = nl.program_ir.intensional_database()
+        q_sym = ir.Symbol("Q")
+        q_union = idb[q_sym]
+        return q_union.formulas[0]
+
+    def test_edb_body_atom_types(self):
+        """Simple EDB rule: body-predicate args have resolved types."""
         from ....frontend.deterministic_frontend import NeurolangDL
 
         nl = NeurolangDL()
@@ -165,25 +184,57 @@ class TestTypeResolutionIntegration:
 
         with nl.scope as e:
             e.Q[e.x, e.y] = e.R[e.x, e.y]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[0].args[1].type is str
             res = nl.query((e.x, e.y), e.Q[e.x, e.y])
 
         assert len(res) == 2
         assert set(res) == {(10, "hello"), (20, "world")}
 
-    def test_partial_type_resolution_with_mixed_predicates(self):
+    def test_multi_column_body_atom_types(self):
+        """Three-column EDB: all column types resolved."""
         from ....frontend.deterministic_frontend import NeurolangDL
 
         nl = NeurolangDL()
-        nl.add_tuple_set([(1, 2.5), (3, 4.5)], name="R")
+        nl.add_tuple_set(
+            [(1, 2.5, "a"), (3, 4.5, "b")], name="R"
+        )
 
         with nl.scope as e:
-            e.Q[e.x, e.y] = e.R[e.x, e.y]
-            res = nl.query((e.x, e.y), e.Q[e.x, e.y])
+            e.Q[e.x, e.y, e.z] = e.R[e.x, e.y, e.z]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[0].args[1].type is float
+            assert atoms[0].args[2].type is str
+            res = nl.query((e.x, e.y, e.z), e.Q[e.x, e.y, e.z])
 
         assert len(res) == 2
-        assert set(res) == {(1, 2.5), (3, 4.5)}
+        assert set(res) == {(1, 2.5, "a"), (3, 4.5, "b")}
 
-    def test_conjunctive_body_rule_in_full_solver(self):
+    def test_type_unification_in_join_body_atoms(self):
+        """Join variable in conjunctive body has unified type."""
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 2), (3, 4)], name="R")
+        nl.add_tuple_set([(1, 10), (3, 30)], name="S")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y, e.z] = e.R[e.x, e.y] & e.S[e.x, e.z]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[1].args[0].type is int
+            res = nl.query((e.x, e.y, e.z), e.Q[e.x, e.y, e.z])
+
+        assert len(res) == 2
+        assert set(res) == {(1, 2, 10), (3, 4, 30)}
+
+    def test_conjunctive_body_rule_query_result(self):
+        """Conjunctive body query produces correct results."""
         from ....frontend.deterministic_frontend import NeurolangDL
 
         nl = NeurolangDL()
@@ -196,3 +247,98 @@ class TestTypeResolutionIntegration:
 
         assert len(res) == 2
         assert set(res) == {(1, "a", 10), (2, "b", 20)}
+
+    def test_partial_type_resolution_body_atoms(self):
+        """
+        Mixed typed/untyped EDBs: only known column types resolved,
+        untyped variables remain Unknown.
+        """
+        from ....frontend.deterministic_frontend import NeurolangDL
+        from ....type_system import Unknown
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1,)], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x] & e.S[e.y]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[1].args[0].type is Unknown
+
+    def test_head_predicate_type_is_bool(self):
+        """
+        After resolution the head FunctionApplication type is bool,
+        preventing re-matching by FunctionApplication[Unknown].
+        """
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 2.5)], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x, e.y]
+            impl = self._get_stored_implication(nl)
+            assert impl.consequent.type is bool
+
+    def test_constant_argument_body_atom_types(self):
+        """EDB with constant argument: variable arg still resolved."""
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 3), (3, 4)], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x] = e.R[e.x, 3]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            # The constant 3 is not a Symbol, so its type is irrelevant
+            res = nl.query((e.x,), e.Q[e.x])
+
+        assert len(res) == 1
+        assert set(res) == {(1,)}
+
+    def test_predicate_symbol_type_in_symbol_table(self):
+        """
+        Predicate symbol in the program's symbol table has its type
+        set (from the EDB or builtin entry), not left as Unknown.
+        """
+        from ....frontend.deterministic_frontend import NeurolangDL
+        from .... import expressions as ir
+        from ....type_system import Unknown
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 2.5)], name="R")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x, e.y]
+
+        r_entry = nl.program_ir.symbol_table.get(ir.Symbol("R"))
+        assert r_entry is not None
+        assert r_entry.type is not Unknown
+
+    def test_region_frontend_solver_direct_type_resolution(self):
+        """
+        Using RegionFrontendDatalogSolver directly (the class where
+        TypeResolutionMixin is wired into MRO) resolves IR Symbol types
+        identically to the minimal _TypeResolutionSolver used in unit tests.
+        """
+        from ....frontend.deterministic_frontend import (
+            RegionFrontendDatalogSolver,
+        )
+        from ....datalog.expressions import Implication
+        from ....expressions import Symbol
+
+        solver = RegionFrontendDatalogSolver()
+        R, x, y, Q = Symbol("R"), Symbol("x"), Symbol("y"), Symbol("Q")
+        solver.add_extensional_predicate_from_tuples(
+            R, [(1, 2.5), (3, 4.5)]
+        )
+
+        rule = Implication(Q(x, y), R(x, y))
+        result = solver.walk(rule)
+
+        assert x.type is int
+        assert y.type is float
+        assert result.consequent.type is bool

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -12,6 +12,7 @@ import pytest
 
 from ....datalog.basic_representation import DatalogProgram
 from ....datalog.expressions import Implication
+from ....datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ....expressions import Constant, Symbol
 from ....frontend.type_resolution import TypeResolutionMixin
 from ....logic import Conjunction
@@ -152,6 +153,231 @@ class TestTypeResolutionMixin:
         assert x.type is int
         entry = program.symbol_table[R]
         assert entry.type is not Unknown
+
+    # ------------------------------------------------------------------
+    # Coverage gap: body atom with non-Symbol functor (line 76)
+    # ------------------------------------------------------------------
+
+    def test_constant_functor_body_atom(self, solver):
+        """Body atom with Constant (non-Symbol) functor is skipped
+        without error. Covers line 76 (not isinstance(pred.functor, Symbol))."""
+        from operator import eq
+
+        mixin, _ = solver
+
+        eq_const = Constant(eq)
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), eq_const(x, Constant[int](5)))
+        result = mixin.walk(rule)
+
+        # x stays Unknown — Constant functor has no symbol-table entry
+        assert x.type is Unknown
+        assert isinstance(result, Implication)
+        assert result.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # Coverage gap: row_type is None for an EDB with no rows (line 103)
+    # ------------------------------------------------------------------
+
+    def test_edb_with_no_rows(self, solver):
+        """An EDB registered with no tuples has no row_type,
+        so _column_types_from_entry returns None and the predicate
+        contributes no type information. Covers line 103."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [])
+
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), R(x))
+        mixin.walk(rule)
+
+        # No row type info means no type propagation
+        assert x.type is Unknown
+        assert rule.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # Coverage gap: column types can be Unknown (line 88)
+    # ------------------------------------------------------------------
+
+    def test_unknown_column_type_skipped(self, solver):
+        """When a predicate has a column type of Unknown, the type
+        resolution skips that column. Covers line 88
+        (if inferred is Unknown: continue)."""
+        mixin, program = solver
+
+        from typing import Tuple
+
+        R = Symbol("R")
+        # Create a WRAS with explicit row_type where one column is Unknown
+        wras = WrappedRelationalAlgebraSet(
+            iterable=[(1, 2.5)],
+            row_type=Tuple[int, Unknown],
+            verify_row_type=False,
+        )
+        program.symbol_table[R] = Constant[AbstractSet[Tuple[int, Unknown]]](
+            wras, auto_infer_type=False, verify_type=False
+        )
+
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x, y), R(x, y))
+        mixin.walk(rule)
+
+        # First column (int) propagates to x
+        assert x.type is int
+        # Second column (Unknown) is skipped — y stays Unknown
+        assert y.type is Unknown
+        assert rule.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # Coverage gap: type unification with compatible types (lines 91-97)
+    # ------------------------------------------------------------------
+
+    def test_type_unification_compatible_types(self, solver):
+        """When two EDBs share a join variable with compatible but
+        different types (e.g. int vs int64), the types are unified.
+        Covers lines 91-97 (unify_types branch)."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1, 2.5)])
+        S = Symbol("S")
+        program.add_extensional_predicate_from_tuples(S, [(1, 10)])
+
+        x = Symbol("x")
+        y = Symbol("y")
+        z = Symbol("z")
+        Q = Symbol("Q")
+
+        conj = Conjunction((R(x, y), S(x, z)))
+        rule = Implication(Q(x, y, z), conj)
+        mixin.walk(rule)
+
+        # x is shared between R and S, both have int
+        assert x.type is int
+        assert y.type is float
+        assert z.type is int
+
+    # ------------------------------------------------------------------
+    # Coverage gap: callable with Ellipsis / variadic args (line 109)
+    # ------------------------------------------------------------------
+
+    def test_callable_with_variadic_args(self, solver):
+        """A builtin with variadic Callable[..., bool] type has no
+        parameter types to extract — _column_types_from_entry returns
+        None via the Ellipsis check. Covers line 109."""
+        mixin, program = solver
+
+        fn_sym = Symbol("fn")
+        program.symbol_table[fn_sym] = Constant[Callable[..., bool]](
+            lambda x: True, auto_infer_type=False, verify_type=False
+        )
+
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), fn_sym(x))
+        mixin.walk(rule)
+
+        # Variadic callable has no resolved parameter types
+        assert x.type is Unknown
+        assert rule.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # Coverage gap: entry is neither EDB nor callable (line 112)
+    # ------------------------------------------------------------------
+
+    def test_non_edb_non_callable_entry(self, solver):
+        """A symbol-table entry whose value is neither a
+        WrappedRelationalAlgebraSet nor a callable causes
+        _column_types_from_entry to return None.
+        Covers lines 82 and 112."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.symbol_table[R] = Constant[int](42)
+
+        x = Symbol("x")
+        Q = Symbol("Q")
+
+        rule = Implication(Q(x), R(x))
+        mixin.walk(rule)
+
+        # No type info from a plain int constant
+        assert x.type is Unknown
+        assert rule.consequent.type is bool
+
+
+
+    # ------------------------------------------------------------------
+    # User requested: several elements in conjunction
+    # ------------------------------------------------------------------
+
+    def test_several_conjunctive_elements(self, solver):
+        """Rule with a 3-way conjunctive body resolves all variable
+        types correctly."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1, 2)])
+        S = Symbol("S")
+        program.add_extensional_predicate_from_tuples(S, [(2, 3)])
+        T = Symbol("T")
+        program.add_extensional_predicate_from_tuples(T, [(3, 4)])
+
+        x = Symbol("x")
+        y = Symbol("y")
+        z = Symbol("z")
+        w = Symbol("w")
+        Q = Symbol("Q")
+
+        conj = Conjunction((R(x, y), S(y, z), T(z, w)))
+        rule = Implication(Q(x, y, z, w), conj)
+        mixin.walk(rule)
+
+        assert x.type is int
+        assert y.type is int
+        assert z.type is int
+        assert w.type is int
+        assert rule.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # User requested: predicates with equalities
+    # ------------------------------------------------------------------
+
+    def test_equality_predicate_in_body(self, solver):
+        """Rule body with an equality atom (Constant functor like
+        operator.eq from 'y == 5') does not block type resolution
+        on shared variables that also appear in an EDB predicate."""
+        mixin, program = solver
+
+        from operator import eq
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1, 2.5)])
+
+        eq_sym = Symbol("eq")
+        eq_const = Constant(eq)  # functor used by parsed "y == 5"
+
+        x = Symbol("x")
+        y = Symbol("y")
+        Q = Symbol("Q")
+
+        body = Conjunction((R(x, y), eq_const(y, Constant[float](2.5))))
+        rule = Implication(Q(x, y), body)
+        mixin.walk(rule)
+
+        # x and y get types from R (the EDB), not from the equality atom
+        assert x.type is int
+        assert y.type is float
+        assert rule.consequent.type is bool
 
 
 class TestTypeResolutionIntegration:
@@ -342,3 +568,90 @@ class TestTypeResolutionIntegration:
         assert x.type is int
         assert y.type is float
         assert result.consequent.type is bool
+
+    # ------------------------------------------------------------------
+    # User requested: negation in body via full solver
+    # ------------------------------------------------------------------
+
+    def test_negation_in_body_type_propagation(self):
+        """Negation in the rule body does not block type resolution
+        on the positive EDB predicate. Uses the full solver with
+        negation support."""
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 2), (2, 3)], name="R")
+        nl.add_tuple_set([(1,)], name="S")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y] = e.R[e.x, e.y] & ~e.S[e.x]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            # x and y get their types from R
+            assert atoms[0].args[0].type is int
+            assert atoms[0].args[1].type is int
+            res = nl.query((e.x, e.y), e.Q[e.x, e.y])
+
+        assert len(res) == 1
+        assert set(res) == {(2, 3)}
+
+    # ------------------------------------------------------------------
+    # User requested: several elements in conjunction via full solver
+    # ------------------------------------------------------------------
+
+    def test_several_conjunctive_elements_type_propagation(self):
+        """A 3-way conjunctive body resolves all shared variable
+        types correctly in the full solver."""
+        from ....frontend.deterministic_frontend import NeurolangDL
+
+        nl = NeurolangDL()
+        nl.add_tuple_set([(1, 2), (3, 4)], name="R")
+        nl.add_tuple_set([(2, 3), (4, 5)], name="S")
+        nl.add_tuple_set([(3, 10), (5, 20)], name="T")
+
+        with nl.scope as e:
+            e.Q[e.x, e.y, e.z, e.w] = e.R[e.x, e.y] & e.S[e.y, e.z] & e.T[e.z, e.w]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[0].args[1].type is int
+            assert atoms[1].args[0].type is int
+            assert atoms[1].args[1].type is int
+            assert atoms[2].args[0].type is int
+            assert atoms[2].args[1].type is int
+            res = nl.query((e.x, e.y, e.z, e.w), e.Q[e.x, e.y, e.z, e.w])
+
+        assert len(res) == 2
+        assert set(res) == {(1, 2, 3, 10), (3, 4, 5, 20)}
+
+    # ------------------------------------------------------------------
+    # User requested: equality predicate in body via full solver
+    # ------------------------------------------------------------------
+
+    def test_equality_predicate_type_propagation(self):
+        """An equality atom in the rule body (parsed from 'y == 5')
+        does not interrupt type resolution on variables shared with
+        EDB predicates. Uses text-based Datalog to express equality."""
+        from ....frontend.deterministic_frontend import NeurolangDL
+        from .... import expressions as ir
+
+        nl = NeurolangDL()
+        nl.execute_datalog_program(
+            """
+        R(1, 3)
+        R(2, 5)
+        R(3, 7)
+        Q(x) :- R(x, y), (y == 5)
+        """
+        )
+
+        idb = nl.program_ir.intensional_database()
+        q_union = idb[ir.Symbol("Q")]
+        impl = q_union.formulas[0]
+        atoms = self._get_body_atoms(impl)
+        # First body atom is R(x, y) — x and y get types from R
+        r_atom = atoms[0]
+        assert r_atom.args[0].type is int
+        assert r_atom.args[1].type is int
+        # Second body atom is y == 5 (Constant functor) — skipped
+        assert impl.consequent.type is bool

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -1,23 +1,21 @@
-"""Tests for TypeResolutionMixin.
+"""
+Tests for TypeResolutionMixin.
 
 Validates that types from EDB predicates and builtin functions are
 propagated to variable symbols in Datalog rules, and that rules with
 no resolvable type information are passed through unchanged.
 """
 
-from typing import AbstractSet, Callable, Tuple
+from typing import Callable
 
 import pytest
 
-from .... import expressions as ir
 from ....datalog.basic_representation import DatalogProgram
 from ....datalog.expressions import Implication
-from ....datalog.wrapped_collections import WrappedRelationalAlgebraFrozenSet
-from ....expressions import Constant, FunctionApplication, Symbol
+from ....expressions import Constant, Symbol
 from ....frontend.type_resolution import TypeResolutionMixin
 from ....logic import Conjunction
 from ....type_system import Unknown
-from ....utils import NamedRelationalAlgebraFrozenSet
 
 
 def _dummy_fn(a: int, b: float) -> bool:
@@ -25,8 +23,10 @@ def _dummy_fn(a: int, b: float) -> bool:
 
 
 class _TypeResolutionSolver(TypeResolutionMixin, DatalogProgram):
-    """Combined solver so that self.walk(expression) flows through
-    to DatalogProgram.statement_intensional after type resolution."""
+    """
+    Combined solver so that self.walk(expression) flows through
+    to DatalogProgram.statement_intensional after type resolution.
+    """
 
 
 @pytest.fixture
@@ -34,13 +34,6 @@ def solver():
     """Create a _TypeResolutionSolver with no EDB predicates loaded."""
     s = _TypeResolutionSolver()
     return s, s
-
-
-def _typed_symbol(name, type_):
-    """Helper to create a Symbol with a specific type annotation."""
-    s = Symbol(name)
-    s.type = type_
-    return s
 
 
 class TestTypeResolutionMixin:
@@ -87,7 +80,7 @@ class TestTypeResolutionMixin:
         assert y.type is not Unknown
 
     def test_rule_passes_through_when_no_types_available(self, solver):
-        mixin, program = solver
+        mixin, _ = solver
 
         R = Symbol("R")
         x = Symbol("x")

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -269,6 +269,41 @@ class TestTypeResolutionMixin:
     # Coverage gap: callable with Ellipsis / variadic args (line 109)
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Coverage gap: type unification failure via exception (lines 92-95)
+    # ------------------------------------------------------------------
+
+    def test_type_unification_with_incompatible_types(self, solver):
+        """When two EDBs share a join variable with incompatible types
+        (here int vs str), unify_types raises NeuroLangTypeException.
+        The exception is caught and the predicate is skipped.
+        Covers lines 92-95 (except/continue in unification path)."""
+        mixin, program = solver
+
+        R = Symbol("R")
+        program.add_extensional_predicate_from_tuples(R, [(1, "a")])
+        S = Symbol("S")
+        program.add_extensional_predicate_from_tuples(S, [("x", 2.5)])
+
+        x = Symbol("x")
+        y = Symbol("y")
+        z = Symbol("z")
+        Q = Symbol("Q")
+
+        # R(x, y) sets x.type = int, y.type = str
+        # S(x, z) has row_type Tuple[str, float], would infer x.type = str
+        # int vs str are incompatible → unify_types raises → continue
+        conj = Conjunction((R(x, y), S(x, z)))
+        rule = Implication(Q(x, y, z), conj)
+        mixin.walk(rule)
+
+        # x still has its type from R (the continue only skips the
+        # current arg in the for loop, not the whole predicate)
+        assert x.type is int
+        assert y.type is str
+        # z gets float from S independently
+        assert z.type is float
+
     def test_callable_with_variadic_args(self, solver):
         """A builtin with variadic Callable[..., bool] type has no
         parameter types to extract — _column_types_from_entry returns
@@ -529,16 +564,22 @@ class TestTypeResolutionIntegration:
         """
         Predicate symbol in the program's symbol table has its type
         set (from the EDB or builtin entry), not left as Unknown.
+        Variable types across diverse column types are resolved.
         """
         from ....frontend.deterministic_frontend import NeurolangDL
         from .... import expressions as ir
         from ....type_system import Unknown
 
         nl = NeurolangDL()
-        nl.add_tuple_set([(1, 2.5)], name="R")
+        nl.add_tuple_set([(1, "hello", 2.5)], name="R")
 
         with nl.scope as e:
-            e.Q[e.x, e.y] = e.R[e.x, e.y]
+            e.Q[e.x, e.y, e.z] = e.R[e.x, e.y, e.z]
+            impl = self._get_stored_implication(nl)
+            atoms = self._get_body_atoms(impl)
+            assert atoms[0].args[0].type is int
+            assert atoms[0].args[1].type is str
+            assert atoms[0].args[2].type is float
 
         r_entry = nl.program_ir.symbol_table.get(ir.Symbol("R"))
         assert r_entry is not None
@@ -557,16 +598,20 @@ class TestTypeResolutionIntegration:
         from ....expressions import Symbol
 
         solver = RegionFrontendDatalogSolver()
-        R, x, y, Q = Symbol("R"), Symbol("x"), Symbol("y"), Symbol("Q")
+        R, x, y, z, Q = (
+            Symbol("R"), Symbol("x"), Symbol("y"),
+            Symbol("z"), Symbol("Q"),
+        )
         solver.add_extensional_predicate_from_tuples(
-            R, [(1, 2.5), (3, 4.5)]
+            R, [(1, "hello", 2.5), (3, "world", 4.5)]
         )
 
-        rule = Implication(Q(x, y), R(x, y))
+        rule = Implication(Q(x, y, z), R(x, y, z))
         result = solver.walk(rule)
 
         assert x.type is int
-        assert y.type is float
+        assert y.type is str
+        assert z.type is float
         assert result.consequent.type is bool
 
     # ------------------------------------------------------------------

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -19,18 +19,21 @@ from ....logic import Conjunction
 from ....type_system import Unknown
 from ....utils import NamedRelationalAlgebraFrozenSet
 
+
 def _dummy_fn(a: int, b: float) -> bool:
     return a > b
 
 
+class _TypeResolutionSolver(TypeResolutionMixin, DatalogProgram):
+    """Combined solver so that self.walk(expression) flows through
+    to DatalogProgram.statement_intensional after type resolution."""
+
+
 @pytest.fixture
 def solver():
-    """Create a TypeResolutionMixin wired to a fresh DatalogProgram's
-    symbol table, with no EDB predicates loaded."""
-    program = DatalogProgram()
-    mixin = TypeResolutionMixin()
-    mixin.symbol_table = program.symbol_table
-    return mixin, program
+    """Create a _TypeResolutionSolver with no EDB predicates loaded."""
+    s = _TypeResolutionSolver()
+    return s, s
 
 
 def _typed_symbol(name, type_):
@@ -42,8 +45,6 @@ def _typed_symbol(name, type_):
 
 class TestTypeResolutionMixin:
     def test_edb_predicate_body_resolves_variable_types(self, solver):
-        """A single EDB predicate in the body provides column types
-        for the rule variables."""
         mixin, program = solver
 
         R = Symbol("R")
@@ -67,8 +68,6 @@ class TestTypeResolutionMixin:
         assert y.type is float or issubclass(y.type, float)
 
     def test_conjunctive_body_resolves_variables(self, solver):
-        """When the body is a Conjunction with an EDB predicate,
-        variable types are still resolved."""
         mixin, program = solver
 
         R = Symbol("R")
@@ -78,7 +77,6 @@ class TestTypeResolutionMixin:
 
         x = Symbol("x")
         y = Symbol("y")
-        t = Symbol("t")
         Q = Symbol("Q")
 
         conj = Conjunction((R(x, y),))
@@ -88,9 +86,7 @@ class TestTypeResolutionMixin:
         assert x.type is not Unknown
         assert y.type is not Unknown
 
-    def test_skipped_when_no_types_available(self, solver):
-        """When no body predicate has a known type in the symbol table,
-        the implication is returned unchanged."""
+    def test_rule_passes_through_when_no_types_available(self, solver):
         mixin, program = solver
 
         R = Symbol("R")
@@ -101,12 +97,9 @@ class TestTypeResolutionMixin:
         result = mixin.walk(rule)
 
         assert x.type is Unknown
-        assert result is rule
+        assert isinstance(result, type(rule))
 
     def test_partial_resolution_mixed_predicates(self, solver):
-        """When some body predicates have known types and others don't,
-        variables that appear in the typed predicate get their types
-        resolved."""
         mixin, program = solver
 
         R = Symbol("R")
@@ -125,8 +118,6 @@ class TestTypeResolutionMixin:
         assert y.type is Unknown
 
     def test_builtin_callable_body_resolves_arg_types(self, solver):
-        """A body predicate whose functor is a builtin Callable
-        provides parameter types."""
         mixin, program = solver
 
         fn_sym = Symbol("fn")
@@ -145,8 +136,6 @@ class TestTypeResolutionMixin:
         assert y.type is not Unknown
 
     def test_constant_arguments_do_not_block_typed_predicates(self, solver):
-        """Constant arguments in body predicates don't block type
-        inference from the predicate's column types."""
         mixin, program = solver
 
         R = Symbol("R")

--- a/neurolang/frontend/datalog/tests/test_type_resolution.py
+++ b/neurolang/frontend/datalog/tests/test_type_resolution.py
@@ -55,10 +55,8 @@ class TestTypeResolutionMixin:
         rule = Implication(Q(x, y), R(x, y))
         mixin.walk(rule)
 
-        assert x.type is not Unknown
-        assert y.type is not Unknown
-        assert x.type is int or issubclass(x.type, int)
-        assert y.type is float or issubclass(y.type, float)
+        assert x.type is int
+        assert y.type is float
 
     def test_conjunctive_body_resolves_variables(self, solver):
         mixin, program = solver
@@ -76,8 +74,8 @@ class TestTypeResolutionMixin:
         rule = Implication(Q(x, y), conj)
         mixin.walk(rule)
 
-        assert x.type is not Unknown
-        assert y.type is not Unknown
+        assert x.type is int
+        assert y.type is str
 
     def test_rule_passes_through_when_no_types_available(self, solver):
         mixin, _ = solver
@@ -91,6 +89,8 @@ class TestTypeResolutionMixin:
 
         assert x.type is Unknown
         assert isinstance(result, type(rule))
+        # Head FA type set to bool prevents infinite re-matching
+        assert rule.consequent.type is bool
 
     def test_partial_resolution_mixed_predicates(self, solver):
         mixin, program = solver
@@ -107,7 +107,7 @@ class TestTypeResolutionMixin:
         rule = Implication(Q(x, y), conj)
         mixin.walk(rule)
 
-        assert x.type is not Unknown
+        assert x.type is int
         assert y.type is Unknown
 
     def test_builtin_callable_body_resolves_arg_types(self, solver):
@@ -125,8 +125,8 @@ class TestTypeResolutionMixin:
         rule = Implication(Q(x, y), fn_sym(x, y))
         mixin.walk(rule)
 
-        assert x.type is not Unknown
-        assert y.type is not Unknown
+        assert x.type is int
+        assert y.type is float
 
     def test_constant_arguments_do_not_block_typed_predicates(self, solver):
         mixin, program = solver
@@ -142,4 +142,4 @@ class TestTypeResolutionMixin:
         rule = Implication(Q(x), R(x, Constant[int](3)))
         mixin.walk(rule)
 
-        assert x.type is not Unknown
+        assert x.type is int

--- a/neurolang/frontend/deterministic_frontend.py
+++ b/neurolang/frontend/deterministic_frontend.py
@@ -20,6 +20,7 @@ from .datalog.sugar import (
     TranslateSelectByFirstColumn,
     TranslateHeadConstantsToEqualities
 )
+from .type_resolution import TypeResolutionMixin
 from ..commands import CommandsMixin
 from .frontend_extensions import NumpyFunctionsMixin
 from .query_resolution_datalog import QueryBuilderDatalog
@@ -72,6 +73,7 @@ class RegionFrontendDatalogSolver(
     TranslateSSugarToSelectByColumn,
     TranslateSelectByFirstColumn,
     TranslateHeadConstantsToEqualities,
+    TypeResolutionMixin,
     Fol2DatalogMixin,
     RegionSolver,
     CommandsMixin,

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -26,6 +26,7 @@ from ..expressions import (
     FunctionApplication,
     Symbol,
 )
+from ..logic import Conjunction
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -48,8 +49,8 @@ class TypeResolutionMixin(PatternWalker):
     """
 
     @add_match(
-        Implication(FunctionApplication(Symbol, ...), Expression),
-        lambda e: e.consequent.type is Unknown,
+        Implication(FunctionApplication[Unknown](Symbol, ...), Expression),
+        lambda e: isinstance(e.antecedent, (FunctionApplication, Conjunction)),
     )
     def resolve_types(self, expression):
         head = expression.consequent
@@ -57,9 +58,10 @@ class TypeResolutionMixin(PatternWalker):
 
         self._resolve_body_types(body)
 
-        # Set the head FA type to bool to prevent re-matching on the
-        # guard (which checks e.consequent.type is Unknown).
-        head.__dict__["type"] = bool
+        # Change the head FA class to FunctionApplication[bool] so the
+        # FunctionApplication[Unknown] pattern no longer matches on
+        # re-entry via self.walk().
+        head.change_type(bool)
 
         return self.walk(expression)
 

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -18,15 +18,14 @@ from typing_inspect import is_callable_type
 
 from ..datalog.expression_processing import extract_logic_atoms
 from ..datalog.expressions import Implication
+from ..datalog.negation import is_conjunctive_negation
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
 from ..expressions import (
     Constant,
-    Expression,
     FunctionApplication,
     Symbol,
 )
-from ..logic import Conjunction
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -49,8 +48,8 @@ class TypeResolutionMixin(PatternWalker):
     """
 
     @add_match(
-        Implication(FunctionApplication[Unknown](Symbol, ...), Expression),
-        lambda e: isinstance(e.antecedent, (FunctionApplication, Conjunction)),
+        Implication(FunctionApplication[Unknown](Symbol, ...), ...),
+        lambda e: is_conjunctive_negation(e.antecedent),
     )
     def resolve_types(self, expression):
         head = expression.consequent
@@ -60,8 +59,10 @@ class TypeResolutionMixin(PatternWalker):
 
         # Change the head FA class to FunctionApplication[bool] so the
         # FunctionApplication[Unknown] pattern no longer matches on
-        # re-entry via self.walk().
+        # re-entry via self.walk(). Also clear any instance 'type'
+        # attribute that would shadow the class-level type.
         head.change_type(bool)
+        head.__dict__.pop("type", None)
 
         return self.walk(expression)
 

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -4,8 +4,10 @@ Type resolution mixin for RegionFrontendDatalogSolver.
 Propagates type information across Datalog rule predicates and variables
 using Unknown as a marker for unprocessed types.  Extracts types from
 extensional database (EDB) predicates which carry concrete
-AbstractSet[Tuple[...]] types and from builtin functions which carry
-Callable types and propagates them to variable symbols.
+AbstractSet[Tuple[...]] types, from builtin functions which carry
+Callable types, and from intensional database (IDB) predicates whose
+resolved rules already carry type information on their head argument
+symbols.  Propagates these types to body variable symbols.
 
 Matches Implication nodes whose head FunctionApplication still has an
 Unknown type, resolves body-predicate types, marks the head as processed
@@ -14,10 +16,13 @@ handlers (e.g. DatalogProgramMixin.statement_intensional) can register
 the rule.
 """
 
+import warnings
+
 from typing_inspect import is_callable_type
 
 from ..datalog.expression_processing import extract_logic_atoms
 from ..datalog.expressions import Implication
+from ..datalog.magic_sets import AdornedSymbol
 from ..datalog.negation import is_conjunctive_negation
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
@@ -26,6 +31,7 @@ from ..expressions import (
     FunctionApplication,
     Symbol,
 )
+from ..logic import Union
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -55,46 +61,116 @@ class TypeResolutionMixin(PatternWalker):
         head = expression.consequent
         body = expression.antecedent
 
+        # During magic-sets rewriting the adorned-datalog walker
+        # creates rules whose head functor is an AdornedSymbol.
+        # The original rules were already resolved — skip here.
+        if isinstance(head.functor, AdornedSymbol):
+            head.change_type(bool)
+            return self.walk(expression)
+
         self._resolve_body_types(body)
+
+        # Propagate resolved body Symbol types to head args by name.
+        # The frontend creates distinct Symbol objects for head vs body
+        # — without this, _column_types_from_idb_entry would see only
+        # Unknown on the head args and IDB propagation would fail.
+        self._propagate_types_to_head(head, body)
 
         # Change the head FA class to FunctionApplication[bool] so the
         # FunctionApplication[Unknown] pattern no longer matches on
-        # re-entry via self.walk(). Also clear any instance 'type'
-        # attribute that would shadow the class-level type.
+        # re-entry via self.walk().
         head.change_type(bool)
-        head.__dict__.pop("type", None)
 
         return self.walk(expression)
 
     def _resolve_body_types(self, body):
         predicates = list(extract_logic_atoms(body))
+
+        # During magic-sets rewriting the adorned-datalog walker
+        # processes adorned rules — skip entirely (the original
+        # rules were already resolved by the main solver).  Detect
+        # this by checking whether any body functor is an
+        # AdornedSymbol (only the adorned walker produces these).
+        if any(
+            isinstance(p, FunctionApplication)
+            and isinstance(p.functor, AdornedSymbol)
+            for p in predicates
+        ):
+            return
+
         for pred in predicates:
             if (
                 not isinstance(pred, FunctionApplication)
                 or not isinstance(pred.functor, Symbol)
             ):
                 continue
+
             entry = self.symbol_table.get(pred.functor)
-            if entry is None or not isinstance(entry, Constant):
+            if entry is None:
+                warnings.warn(
+                    f"Symbol {pred.functor.name} used in rule body "
+                    f"has no entry in the symbol table. Types cannot "
+                    f"be inferred for this predicate.",
+                    UserWarning,
+                )
                 continue
-            col_types = self._column_types_from_entry(entry)
+            if isinstance(entry, Constant):
+                col_types = self._column_types_from_entry(entry)
+            elif isinstance(entry, Union):
+                col_types = self._column_types_from_idb_entry(entry)
+            else:
+                continue
             if col_types is None:
                 continue
             for i, arg in enumerate(pred.args):
                 if not isinstance(arg, Symbol) or i >= len(col_types):
                     continue
-                inferred = col_types[i]
-                if inferred is Unknown:
+                self._set_or_unify_type(arg, col_types[i])
+
+    def _set_or_unify_type(self, symbol, inferred):
+        """Set a Symbol's type to inferred, or unify with an existing
+        type if both are informative and incompatible.
+        """
+        if inferred is Unknown:
+            return
+        if symbol.type is Unknown:
+            symbol.__dict__["type"] = inferred
+        elif not is_leq_informative(symbol.type, inferred):
+            try:
+                unified = unify_types(symbol.type, inferred)
+            except NeuroLangTypeException:
+                return
+            if unified is not symbol.type:
+                symbol.__dict__["type"] = unified
+
+    def _propagate_types_to_head(self, head, body):
+        """Copy type information from body Symbols to matching head
+        Symbols by name, so the stored Implication's head args carry
+        resolved types for downstream IDB propagation.
+
+        The frontend creates distinct Symbol objects for head vs body
+        even when they share the same variable name.  Without this
+        step, _column_types_from_idb_entry would read Unknown from
+        the head args and IDB type chains would be broken.
+        """
+        head_args = {
+            arg.name: arg
+            for arg in head.args
+            if isinstance(arg, Symbol)
+        }
+        if not head_args:
+            return
+
+        for pred in extract_logic_atoms(body):
+            if not isinstance(pred, FunctionApplication):
+                continue
+            for arg in pred.args:
+                if not isinstance(arg, Symbol):
                     continue
-                if arg.type is Unknown:
-                    arg.__dict__["type"] = inferred
-                elif not is_leq_informative(arg.type, inferred):
-                    try:
-                        unified = unify_types(arg.type, inferred)
-                    except NeuroLangTypeException:
-                        continue
-                    if unified is not arg.type:
-                        arg.__dict__["type"] = unified
+                head_arg = head_args.get(arg.name)
+                if head_arg is None:
+                    continue
+                self._set_or_unify_type(head_arg, arg.type)
 
     def _column_types_from_entry(self, entry):
         if isinstance(entry.value, WrappedRelationalAlgebraSet):
@@ -110,3 +186,44 @@ class TypeResolutionMixin(PatternWalker):
             return tuple(args)
 
         return None
+
+    def _column_types_from_idb_entry(self, entry):
+        """Extract column types from an IDB predicate's resolved rules.
+
+        After type resolution, the head argument symbols of stored
+        implications have their .type attribute set.  This method
+        collects those types by position, unifying across multiple
+        rules that define the same predicate.
+
+        Returns a tuple of types, or None if no type information is
+        available (no formulas or all head args are Unknown).
+        """
+        if not isinstance(entry, Union):
+            return None
+        col_types = None
+        for formula in entry.formulas:
+            if not isinstance(formula, Implication):
+                continue
+            head = formula.consequent
+            if not isinstance(head, FunctionApplication):
+                continue
+            arg_types = tuple(
+                arg.type if isinstance(arg, Symbol) else Unknown
+                for arg in head.args
+            )
+            if col_types is None:
+                col_types = arg_types
+            else:
+                unified = []
+                for t1, t2 in zip(col_types, arg_types):
+                    if t1 is Unknown:
+                        unified.append(t2)
+                    elif t2 is Unknown:
+                        unified.append(t1)
+                    else:
+                        try:
+                            unified.append(unify_types(t1, t2))
+                        except NeuroLangTypeException:
+                            unified.append(t1)
+                col_types = tuple(unified)
+        return col_types

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -1,10 +1,11 @@
-"""Type resolution mixin for RegionFrontendDatalogSolver.
+"""
+Type resolution mixin for RegionFrontendDatalogSolver.
 
 Propagates type information across Datalog rule predicates and variables
 using Unknown as a marker for unprocessed types.  Extracts types from
-extensional database (EDB) predicates (which carry concrete
-AbstractSet[Tuple[...]] types) and from builtin functions (which carry
-Callable types) and propagates them to variable symbols.
+extensional database (EDB) predicates which carry concrete
+AbstractSet[Tuple[...]] types and from builtin functions which carry
+Callable types and propagates them to variable symbols.
 
 Matches Implication nodes with a FunctionApplication or Conjunction
 body and resolves variable types before the expression continues through
@@ -22,24 +23,25 @@ from ..datalog.expressions import Implication
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
 from ..expressions import Constant, FunctionApplication, Symbol
-from ..logic import Conjunction
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
     get_args,
-    infer_type,
     is_leq_informative,
     unify_types,
 )
 
 
 def _implication_has_untyped_body_predicates(expression):
-    """Guard: True when the expression has not yet been processed
-    and any body-predicate argument symbol has Unknown type.
+    """
+    Guard that allows matching when the expression still needs type
+    resolution.
 
-    The handler sets _nl_type_resolved on the expression after the first
-    pass, so subsequent match attempts through self.walk() skip this
-    pattern and fall through to downstream handlers.
+    Returns True when the expression has not yet been processed and any
+    body-predicate argument symbol has Unknown type. The handler sets
+    _nl_type_resolved on the expression after the first pass, so
+    subsequent match attempts through self.walk() skip this pattern and
+    fall through to downstream handlers.
     """
     if getattr(expression, '_nl_type_resolved', False):
         return False
@@ -55,7 +57,8 @@ def _implication_has_untyped_body_predicates(expression):
 
 
 class TypeResolutionMixin(PatternWalker):
-    """PatternWalker mixin that infers and propagates types in Datalog rules.
+    """
+    PatternWalker mixin that infers and propagates types in Datalog rules.
 
     Intercepts Implication nodes to resolve variable types from body-predicate
     functor lookups in the symbol table.  Returns self.walk(expression) to

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -7,22 +7,24 @@ extensional database (EDB) predicates which carry concrete
 AbstractSet[Tuple[...]] types and from builtin functions which carry
 Callable types and propagates them to variable symbols.
 
-Matches Implication nodes with a FunctionApplication or Conjunction
-body and resolves variable types before the expression continues through
-the MRO to handlers such as DatalogProgramMixin.statement_intensional.
-
-Uses a guard to prevent re-processing already-resolved rules.
+Matches FunctionApplication nodes during the walker's recursive traversal,
+leaving Implication handling to downstream MRO handlers such as
+DatalogProgramMixin.statement_intensional.  A catch-all rule walks children
+for all non-Implication expressions so the mixin works with PatternWalker's
+non-recursive walk.
 """
-
-from typing import AbstractSet
 
 from typing_inspect import is_callable_type
 
-from ..datalog.expression_processing import extract_logic_atoms
-from ..datalog.expressions import Implication
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
-from ..expressions import Constant, FunctionApplication, Symbol
+from ..datalog.expressions import Implication
+from ..expressions import (
+    Constant,
+    Expression,
+    FunctionApplication,
+    Symbol,
+)
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -32,67 +34,32 @@ from ..type_system import (
 )
 
 
-def _implication_has_untyped_body_predicates(expression):
-    """
-    Guard that allows matching when the expression still needs type
-    resolution.
-
-    Returns True when the expression has not yet been processed and any
-    body-predicate argument symbol has Unknown type. The handler sets
-    _nl_type_resolved on the expression after the first pass, so
-    subsequent match attempts through self.walk() skip this pattern and
-    fall through to downstream handlers.
-    """
-    if getattr(expression, '_nl_type_resolved', False):
-        return False
-    body = expression.antecedent
-    predicates = list(extract_logic_atoms(body))
-    for pred in predicates:
-        if not isinstance(pred, FunctionApplication):
-            continue
-        if any(isinstance(arg, Symbol) and arg.type is Unknown
-               for arg in pred.args):
-            return True
-    return False
-
-
 class TypeResolutionMixin(PatternWalker):
     """
     PatternWalker mixin that infers and propagates types in Datalog rules.
 
-    Intercepts Implication nodes to resolve variable types from body-predicate
-    functor lookups in the symbol table.  Returns self.walk(expression) to
-    re-enter the processing cycle so downstream handlers
-    (e.g. statement_intensional) receive the typed rule.
+    Each FunctionApplication whose functor is a Symbol is checked against
+    the symbol table.  If the functor maps to an EDB relation, column
+    types are propagated to argument symbols.  For builtin functions with
+    Callable types, parameter types are propagated similarly.
+
+    A catch-all rule recursively walks children of all expressions except
+    Implication, which is left to downstream handlers such as
+    statement_intensional.
     """
 
-    @add_match(
-        Implication,
-        _implication_has_untyped_body_predicates,
-    )
-    def resolve_types(self, expression):
-        self._resolve_types_from_body(expression)
-        expression._nl_type_resolved = True
-        return self.walk(expression)
+    @add_match(FunctionApplication(Symbol, ...))
+    def resolve_predicate_types(self, expression):
+        functor = expression.functor
+        entry = self.symbol_table.get(functor)
+        if entry is None or not isinstance(entry, Constant):
+            return expression
 
-    def _resolve_types_from_body(self, expression):
-        predicates = list(extract_logic_atoms(expression.antecedent))
-        for pred in predicates:
-            if not isinstance(pred, FunctionApplication):
-                continue
-            functor = pred.functor
-            if not isinstance(functor, Symbol):
-                continue
-            entry = self.symbol_table.get(functor)
-            if entry is None or not isinstance(entry, Constant):
-                continue
-            col_types = self._column_types_from_entry(entry)
-            if col_types is None:
-                continue
-            self._apply_column_types(pred, col_types)
+        col_types = self._column_types_from_entry(entry)
+        if col_types is None:
+            return expression
 
-    def _apply_column_types(self, predicate, col_types):
-        for i, arg in enumerate(predicate.args):
+        for i, arg in enumerate(expression.args):
             if not isinstance(arg, Symbol) or i >= len(col_types):
                 continue
             inferred = col_types[i]
@@ -108,13 +75,48 @@ class TypeResolutionMixin(PatternWalker):
                 if unified is not arg.type:
                     arg.__dict__['type'] = unified
 
+        return expression
+
+    @add_match(Expression, lambda e: not isinstance(e, Implication))
+    def walk_children(self, expression):
+        """
+        Recursively walk children for non-Implication expressions.
+
+        Downstream MRO handlers such as statement_intensional handle
+        Implication separately, so this catch-all skips it.
+        """
+        args = expression.unapply()
+        new_args = tuple()
+        changed = False
+        for arg in args:
+            if isinstance(arg, Expression):
+                new_arg = self.walk(arg)
+                changed |= new_arg is not arg
+            elif isinstance(arg, tuple) and len(arg) > 0 and isinstance(arg[0], Expression):
+                new_arg, arg_changed = self._walk_tuple(arg)
+                changed |= arg_changed
+            else:
+                new_arg = arg
+            new_args += (new_arg,)
+
+        if changed:
+            return self.walk(expression.apply(*new_args))
+        return expression
+
+    def _walk_tuple(self, arg):
+        changed = False
+        result = list()
+        for sub in arg:
+            walked = self.walk(sub)
+            result.append(walked)
+            changed |= walked is not sub
+        return type(arg)(result), changed
+
     def _column_types_from_entry(self, entry):
         if isinstance(entry.value, WrappedRelationalAlgebraSet):
-            if entry.type is Unknown:
+            row_type = entry.value.row_type
+            if row_type is None:
                 return None
-            if not is_leq_informative(entry.type, AbstractSet):
-                return None
-            row_type = get_args(entry.type)[0]
             return get_args(row_type)
 
         if is_callable_type(entry.type):

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -7,24 +7,17 @@ extensional database (EDB) predicates which carry concrete
 AbstractSet[Tuple[...]] types and from builtin functions which carry
 Callable types and propagates them to variable symbols.
 
-Matches FunctionApplication nodes during the walker's recursive traversal,
-leaving Implication handling to downstream MRO handlers such as
-DatalogProgramMixin.statement_intensional.  A catch-all rule walks children
-for all non-Implication expressions so the mixin works with PatternWalker's
-non-recursive walk.
+Matches FunctionApplication nodes during the walker's recursive traversal.
+Tree recursion is handled by ExpressionWalker in the downstream MRO, so this
+mixin needs no catch-all — only the specific FunctionApplication pattern is
+registered.
 """
 
 from typing_inspect import is_callable_type
 
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
-from ..datalog.expressions import Implication
-from ..expressions import (
-    Constant,
-    Expression,
-    FunctionApplication,
-    Symbol,
-)
+from ..expressions import Constant, FunctionApplication, Symbol
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -43,9 +36,9 @@ class TypeResolutionMixin(PatternWalker):
     types are propagated to argument symbols.  For builtin functions with
     Callable types, parameter types are propagated similarly.
 
-    A catch-all rule recursively walks children of all expressions except
-    Implication, which is left to downstream handlers such as
-    statement_intensional.
+    Because ExpressionWalker (further down the MRO chain) provides the
+    recursive child-walking, this mixin only registers a single specific
+    pattern — no catch-all is needed.
     """
 
     @add_match(FunctionApplication(Symbol, ...))
@@ -76,41 +69,6 @@ class TypeResolutionMixin(PatternWalker):
                     arg.__dict__['type'] = unified
 
         return expression
-
-    @add_match(Expression, lambda e: not isinstance(e, Implication))
-    def walk_children(self, expression):
-        """
-        Recursively walk children for non-Implication expressions.
-
-        Downstream MRO handlers such as statement_intensional handle
-        Implication separately, so this catch-all skips it.
-        """
-        args = expression.unapply()
-        new_args = tuple()
-        changed = False
-        for arg in args:
-            if isinstance(arg, Expression):
-                new_arg = self.walk(arg)
-                changed |= new_arg is not arg
-            elif isinstance(arg, tuple) and len(arg) > 0 and isinstance(arg[0], Expression):
-                new_arg, arg_changed = self._walk_tuple(arg)
-                changed |= arg_changed
-            else:
-                new_arg = arg
-            new_args += (new_arg,)
-
-        if changed:
-            return self.walk(expression.apply(*new_args))
-        return expression
-
-    def _walk_tuple(self, arg):
-        changed = False
-        result = list()
-        for sub in arg:
-            walked = self.walk(sub)
-            result.append(walked)
-            changed |= walked is not sub
-        return type(arg)(result), changed
 
     def _column_types_from_entry(self, entry):
         if isinstance(entry.value, WrappedRelationalAlgebraSet):

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -138,7 +138,7 @@ class TypeResolutionMixin(PatternWalker):
         except NeuroLangTypeException:
             return
         if unified is not symbol.type:
-            symbol.__dict__["type"] = unified
+            symbol.type = unified
 
     def _propagate_types_to_head(self, head, body):
         """Copy type information from body Symbols to matching head

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -36,7 +36,6 @@ from ..type_system import (
     NeuroLangTypeException,
     Unknown,
     get_args,
-    is_leq_informative,
     unify_types,
 )
 
@@ -128,20 +127,18 @@ class TypeResolutionMixin(PatternWalker):
                 self._set_or_unify_type(arg, col_types[i])
 
     def _set_or_unify_type(self, symbol, inferred):
-        """Set a Symbol's type to inferred, or unify with an existing
-        type if both are informative and incompatible.
+        """Set a Symbol's type to inferred, unifying with its existing
+        type if needed.  Delegates to unify_types which already
+        handles Unknown correctly.
         """
         if inferred is Unknown:
             return
-        if symbol.type is Unknown:
-            symbol.__dict__["type"] = inferred
-        elif not is_leq_informative(symbol.type, inferred):
-            try:
-                unified = unify_types(symbol.type, inferred)
-            except NeuroLangTypeException:
-                return
-            if unified is not symbol.type:
-                symbol.__dict__["type"] = unified
+        try:
+            unified = unify_types(symbol.type, inferred)
+        except NeuroLangTypeException:
+            return
+        if unified is not symbol.type:
+            symbol.__dict__["type"] = unified
 
     def _propagate_types_to_head(self, head, body):
         """Copy type information from body Symbols to matching head
@@ -216,14 +213,9 @@ class TypeResolutionMixin(PatternWalker):
             else:
                 unified = []
                 for t1, t2 in zip(col_types, arg_types):
-                    if t1 is Unknown:
-                        unified.append(t2)
-                    elif t2 is Unknown:
+                    try:
+                        unified.append(unify_types(t1, t2))
+                    except NeuroLangTypeException:
                         unified.append(t1)
-                    else:
-                        try:
-                            unified.append(unify_types(t1, t2))
-                        except NeuroLangTypeException:
-                            unified.append(t1)
                 col_types = tuple(unified)
         return col_types

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -1,0 +1,95 @@
+"""Type resolution mixin for RegionFrontendDatalogSolver.
+
+Propagates type information across Datalog rule predicates and variables
+using Unknown as a marker for unprocessed types.  Extracts types from
+extensional database (EDB) predicates (which carry concrete
+AbstractSet[Tuple[...]] types) and from builtin functions (which carry
+Callable types) and propagates them to variable symbols.
+
+Matches individual FunctionApplication nodes (predicates) during the
+recursive tree walk, leaving Implication processing to downstream MRO
+handlers such as DatalogProgramMixin.statement_intensional.
+"""
+
+from typing import AbstractSet
+
+from typing_inspect import is_callable_type
+
+from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
+from ..expression_walker import ExpressionWalker, add_match
+from ..expressions import Constant, FunctionApplication, Symbol
+from ..type_system import (
+    NeuroLangTypeException,
+    Unknown,
+    get_args,
+    infer_type,
+    is_leq_informative,
+    unify_types,
+)
+
+
+class TypeResolutionMixin(ExpressionWalker):
+    """Walker mixin that infers and propagates types in Datalog rules.
+
+    When walking an Expression tree, each FunctionApplication whose
+    functor is a Symbol is checked against the symbol table.  If the
+    functor maps to an EDB relation (Constant[AbstractSet[Tuple[...]]]),
+    the element types are extracted per-column and applied to the
+    corresponding argument symbols.  For builtin functions with Callable
+    types, parameter types are propagated similarly.
+    """
+
+    @add_match(
+        FunctionApplication(Symbol, ...),
+    )
+    def resolve_predicate_types(self, expression):
+        functor = expression.functor
+        entry = self.symbol_table.get(functor)
+        if entry is None or not isinstance(entry, Constant):
+            return expression
+
+        col_types = self._column_types_from_entry(entry)
+        if col_types is None:
+            return expression
+
+        for i, arg in enumerate(expression.args):
+            if not isinstance(arg, Symbol) or i >= len(col_types):
+                continue
+            inferred = col_types[i]
+            if inferred is Unknown:
+                continue
+            if arg.type is Unknown:
+                arg.__dict__['type'] = inferred
+            elif not is_leq_informative(arg.type, inferred):
+                try:
+                    unified = unify_types(arg.type, inferred)
+                except NeuroLangTypeException:
+                    continue
+                if unified is not arg.type:
+                    arg.__dict__['type'] = unified
+
+        return expression
+
+    def _column_types_from_entry(self, entry):
+        """Extract per-column types from a symbol-table entry.
+
+        For EDB predicates (Constant[AbstractSet[Tuple[T1, T2, ...]]])
+        returns (T1, T2, ...).  For builtin functions
+        (Constant[Callable[[P1, P2, ...], R]]) returns (P1, P2, ...).
+        Returns None when no column-level type info is available.
+        """
+        if isinstance(entry.value, WrappedRelationalAlgebraSet):
+            if entry.type is Unknown:
+                return None
+            if not is_leq_informative(entry.type, AbstractSet):
+                return None
+            row_type = get_args(entry.type)[0]
+            return get_args(row_type)
+
+        if is_callable_type(entry.type):
+            args, _return = get_args(entry.type)
+            if args is Ellipsis or args is ...:
+                return None
+            return tuple(args)
+
+        return None

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -7,17 +7,25 @@ extensional database (EDB) predicates which carry concrete
 AbstractSet[Tuple[...]] types and from builtin functions which carry
 Callable types and propagates them to variable symbols.
 
-Matches FunctionApplication nodes during the walker's recursive traversal.
-Tree recursion is handled by ExpressionWalker in the downstream MRO, so this
-mixin needs no catch-all — only the specific FunctionApplication pattern is
-registered.
+Matches Implication nodes whose head FunctionApplication still has an
+Unknown type, resolves body-predicate types, marks the head as processed
+by setting its function type, and re-enters the walk so downstream
+handlers (e.g. DatalogProgramMixin.statement_intensional) can register
+the rule.
 """
 
 from typing_inspect import is_callable_type
 
+from ..datalog.expression_processing import extract_logic_atoms
+from ..datalog.expressions import Implication
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
-from ..expressions import Constant, FunctionApplication, Symbol
+from ..expressions import (
+    Constant,
+    Expression,
+    FunctionApplication,
+    Symbol,
+)
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -31,44 +39,59 @@ class TypeResolutionMixin(PatternWalker):
     """
     PatternWalker mixin that infers and propagates types in Datalog rules.
 
-    Each FunctionApplication whose functor is a Symbol is checked against
-    the symbol table.  If the functor maps to an EDB relation, column
-    types are propagated to argument symbols.  For builtin functions with
-    Callable types, parameter types are propagated similarly.
-
-    Because ExpressionWalker (further down the MRO chain) provides the
-    recursive child-walking, this mixin only registers a single specific
-    pattern — no catch-all is needed.
+    Matches Implication nodes where the head FunctionApplication type is
+    still Unknown.  The handler extracts atoms from the rule body, looks
+    up their functors in the symbol table, and propagates column/parameter
+    types to argument Symbols.  After resolution, the head
+    FunctionApplication type is set to bool -- this prevents re-matching
+    when self.walk re-enters the processing cycle.
     """
 
-    @add_match(FunctionApplication(Symbol, ...))
-    def resolve_predicate_types(self, expression):
-        functor = expression.functor
-        entry = self.symbol_table.get(functor)
-        if entry is None or not isinstance(entry, Constant):
-            return expression
+    @add_match(
+        Implication(FunctionApplication(Symbol, ...), Expression),
+        lambda e: e.consequent.type is Unknown,
+    )
+    def resolve_types(self, expression):
+        head = expression.consequent
+        body = expression.antecedent
 
-        col_types = self._column_types_from_entry(entry)
-        if col_types is None:
-            return expression
+        self._resolve_body_types(body)
 
-        for i, arg in enumerate(expression.args):
-            if not isinstance(arg, Symbol) or i >= len(col_types):
+        # Set the head FA type to bool to prevent re-matching on the
+        # guard (which checks e.consequent.type is Unknown).
+        head.__dict__["type"] = bool
+
+        return self.walk(expression)
+
+    def _resolve_body_types(self, body):
+        predicates = list(extract_logic_atoms(body))
+        for pred in predicates:
+            if (
+                not isinstance(pred, FunctionApplication)
+                or not isinstance(pred.functor, Symbol)
+            ):
                 continue
-            inferred = col_types[i]
-            if inferred is Unknown:
+            entry = self.symbol_table.get(pred.functor)
+            if entry is None or not isinstance(entry, Constant):
                 continue
-            if arg.type is Unknown:
-                arg.__dict__['type'] = inferred
-            elif not is_leq_informative(arg.type, inferred):
-                try:
-                    unified = unify_types(arg.type, inferred)
-                except NeuroLangTypeException:
+            col_types = self._column_types_from_entry(entry)
+            if col_types is None:
+                continue
+            for i, arg in enumerate(pred.args):
+                if not isinstance(arg, Symbol) or i >= len(col_types):
                     continue
-                if unified is not arg.type:
-                    arg.__dict__['type'] = unified
-
-        return expression
+                inferred = col_types[i]
+                if inferred is Unknown:
+                    continue
+                if arg.type is Unknown:
+                    arg.__dict__["type"] = inferred
+                elif not is_leq_informative(arg.type, inferred):
+                    try:
+                        unified = unify_types(arg.type, inferred)
+                    except NeuroLangTypeException:
+                        continue
+                    if unified is not arg.type:
+                        arg.__dict__["type"] = unified
 
     def _column_types_from_entry(self, entry):
         if isinstance(entry.value, WrappedRelationalAlgebraSet):

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -6,18 +6,23 @@ extensional database (EDB) predicates (which carry concrete
 AbstractSet[Tuple[...]] types) and from builtin functions (which carry
 Callable types) and propagates them to variable symbols.
 
-Matches individual FunctionApplication nodes (predicates) during the
-recursive tree walk, leaving Implication processing to downstream MRO
-handlers such as DatalogProgramMixin.statement_intensional.
+Matches Implication nodes with a FunctionApplication or Conjunction
+body and resolves variable types before the expression continues through
+the MRO to handlers such as DatalogProgramMixin.statement_intensional.
+
+Uses a guard to prevent re-processing already-resolved rules.
 """
 
 from typing import AbstractSet
 
 from typing_inspect import is_callable_type
 
+from ..datalog.expression_processing import extract_logic_atoms
+from ..datalog.expressions import Implication
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
-from ..expression_walker import ExpressionWalker, add_match
+from ..expression_walker import PatternWalker, add_match
 from ..expressions import Constant, FunctionApplication, Symbol
+from ..logic import Conjunction
 from ..type_system import (
     NeuroLangTypeException,
     Unknown,
@@ -28,31 +33,63 @@ from ..type_system import (
 )
 
 
-class TypeResolutionMixin(ExpressionWalker):
-    """Walker mixin that infers and propagates types in Datalog rules.
+def _implication_has_untyped_body_predicates(expression):
+    """Guard: True when the expression has not yet been processed
+    and any body-predicate argument symbol has Unknown type.
 
-    When walking an Expression tree, each FunctionApplication whose
-    functor is a Symbol is checked against the symbol table.  If the
-    functor maps to an EDB relation (Constant[AbstractSet[Tuple[...]]]),
-    the element types are extracted per-column and applied to the
-    corresponding argument symbols.  For builtin functions with Callable
-    types, parameter types are propagated similarly.
+    The handler sets _nl_type_resolved on the expression after the first
+    pass, so subsequent match attempts through self.walk() skip this
+    pattern and fall through to downstream handlers.
+    """
+    if getattr(expression, '_nl_type_resolved', False):
+        return False
+    body = expression.antecedent
+    predicates = list(extract_logic_atoms(body))
+    for pred in predicates:
+        if not isinstance(pred, FunctionApplication):
+            continue
+        if any(isinstance(arg, Symbol) and arg.type is Unknown
+               for arg in pred.args):
+            return True
+    return False
+
+
+class TypeResolutionMixin(PatternWalker):
+    """PatternWalker mixin that infers and propagates types in Datalog rules.
+
+    Intercepts Implication nodes to resolve variable types from body-predicate
+    functor lookups in the symbol table.  Returns self.walk(expression) to
+    re-enter the processing cycle so downstream handlers
+    (e.g. statement_intensional) receive the typed rule.
     """
 
     @add_match(
-        FunctionApplication(Symbol, ...),
+        Implication,
+        _implication_has_untyped_body_predicates,
     )
-    def resolve_predicate_types(self, expression):
-        functor = expression.functor
-        entry = self.symbol_table.get(functor)
-        if entry is None or not isinstance(entry, Constant):
-            return expression
+    def resolve_types(self, expression):
+        self._resolve_types_from_body(expression)
+        expression._nl_type_resolved = True
+        return self.walk(expression)
 
-        col_types = self._column_types_from_entry(entry)
-        if col_types is None:
-            return expression
+    def _resolve_types_from_body(self, expression):
+        predicates = list(extract_logic_atoms(expression.antecedent))
+        for pred in predicates:
+            if not isinstance(pred, FunctionApplication):
+                continue
+            functor = pred.functor
+            if not isinstance(functor, Symbol):
+                continue
+            entry = self.symbol_table.get(functor)
+            if entry is None or not isinstance(entry, Constant):
+                continue
+            col_types = self._column_types_from_entry(entry)
+            if col_types is None:
+                continue
+            self._apply_column_types(pred, col_types)
 
-        for i, arg in enumerate(expression.args):
+    def _apply_column_types(self, predicate, col_types):
+        for i, arg in enumerate(predicate.args):
             if not isinstance(arg, Symbol) or i >= len(col_types):
                 continue
             inferred = col_types[i]
@@ -68,16 +105,7 @@ class TypeResolutionMixin(ExpressionWalker):
                 if unified is not arg.type:
                     arg.__dict__['type'] = unified
 
-        return expression
-
     def _column_types_from_entry(self, entry):
-        """Extract per-column types from a symbol-table entry.
-
-        For EDB predicates (Constant[AbstractSet[Tuple[T1, T2, ...]]])
-        returns (T1, T2, ...).  For builtin functions
-        (Constant[Callable[[P1, P2, ...], R]]) returns (P1, P2, ...).
-        Returns None when no column-level type info is available.
-        """
         if isinstance(entry.value, WrappedRelationalAlgebraSet):
             if entry.type is Unknown:
                 return None

--- a/neurolang/tests/test_expressions.py
+++ b/neurolang/tests/test_expressions.py
@@ -377,16 +377,12 @@ def test_change_type_clears_instance_attribute():
     x = Symbol("x")
     fa = FunctionApplication(f, (x,))
 
-    assert "type" in fa.__dict__, (
-        "FunctionApplication.__init__ should have set an instance "
-        "'type' attribute (via the metaclass or _verify_and_set_type)"
+    assert fa.type is Unknown, (
+        "FunctionApplication with no explicit type should default to Unknown"
     )
-    old_type = fa.__dict__["type"]
 
     fa.change_type(bool)
 
-    assert "type" not in fa.__dict__, (
-        f"Stale instance 'type' ({old_type!r}) was not cleared "
-        f"by change_type(bool). fa.__dict__ still has it."
+    assert fa.type is bool, (
+        f"After change_type(bool), fa.type should be bool, got {fa.type}"
     )
-    assert fa.type is bool

--- a/neurolang/tests/test_expressions.py
+++ b/neurolang/tests/test_expressions.py
@@ -364,3 +364,29 @@ def test_type_printing_option():
     config.disable_expression_type_printing()
     assert repr(x) == "S{x}"
     assert repr(a) == "C{'a'}"
+
+
+def test_change_type_clears_instance_attribute():
+    """change_type must clear any instance 'type' attribute so that
+    the class-level type (set by the class change) is not shadowed.
+    FunctionApplication is the primary case because its __init__
+    calls _verify_and_set_type which stores 'type' in __dict__."""
+    from neurolang.expressions import FunctionApplication, Symbol
+
+    f = Symbol("f")
+    x = Symbol("x")
+    fa = FunctionApplication(f, (x,))
+
+    assert "type" in fa.__dict__, (
+        "FunctionApplication.__init__ should have set an instance "
+        "'type' attribute (via the metaclass or _verify_and_set_type)"
+    )
+    old_type = fa.__dict__["type"]
+
+    fa.change_type(bool)
+
+    assert "type" not in fa.__dict__, (
+        f"Stale instance 'type' ({old_type!r}) was not cleared "
+        f"by change_type(bool). fa.__dict__ still has it."
+    )
+    assert fa.type is bool


### PR DESCRIPTION
Adds `TypeResolutionMixin` (a `PatternWalker`) that infers and propagates variable types in Datalog rules by matching `Implication` nodes whose head `FunctionApplication` still has `Unknown` type, resolving body-predicate functors against the symbol table, and propagating column/parameter types to argument `Symbol` objects.

### How it works

The mixin matches `Implication(FunctionApplication[Unknown](Symbol, ...), ...)` with an `is_conjunctive_negation` guard on the antecedent. The handler:

1. **Resolves body-predicate types** — looks up each body atom's functor in the symbol table, extracts column types:
   - EDB predicates → `WrappedRelationalAlgebraSet.row_type`
   - Builtin functions → `Callable` parameter types
   - IDB predicates → head-arg types from stored `Union` formulas
2. **Sets Symbol types** — propagates column types to body argument `Symbol` objects via `__dict__["type"]`, with `unify_types` for join variables shared across predicates
3. **Propagates types to head** — copies resolved body-Symbol types to matching head Symbols by name (required because the frontend creates distinct `Symbol` objects for head vs body args even when they share variable names)
4. **Prevents re-matching** — changes the head FA class to `FunctionApplication[bool]` via `head.change_type(bool)`
5. **Re-enters the walk** — `self.walk(expression)` routes to downstream MRO handlers such as `DatalogProgramMixin.statement_intensional`

### Magic-sets compatibility

The magic-sets rewrite layer creates `AdornedSymbol` functors in adorned rules. Two guards suppress false-positive warnings:
- Head guard: `isinstance(head.functor, AdornedSymbol)` early-return in `resolve_types`
- Body guard: early return from `_resolve_body_types` when any body functor is `AdornedSymbol`

### Files changed

- `neurolang/frontend/type_resolution.py` — new module with `TypeResolutionMixin` (229 lines)
- `neurolang/frontend/datalog/tests/test_type_resolution.py` — 31 tests (18 unit + 13 integration)
- `neurolang/frontend/deterministic_frontend.py` — import + MRO wiring in `RegionFrontendDatalogSolver`
- `neurolang/expressions.py` — fix `Expression.change_type` / `Constant.change_type` shadowing bug (commit 322fc917)

### Verification

- 31 type resolution tests all passing
- Full frontend suite: 280 passed, 9 skipped (no regressions)
- Full datalog suite: 379 passed, 6 skipped, 1 xpassed (no regressions)
- Coverage: 93% (55 stmts, 3 missing — all unreachable defensive branches)