### PR TITLE
fix(squall): implement 'in ND' dimension annotations producing multi-arg predicates

### DIFF
--- a/neurolang/frontend/datalog/squall_syntax_lark.py
+++ b/neurolang/frontend/datalog/squall_syntax_lark.py
@@ -1162,6 +1162,9 @@ class SquallTransformer(Transformer):
                 var_info = getattr(ng, '_var_info', None)
                 if var_info is not None and isinstance(var_info, tuple):
                     body_syms, head_syms = _resolve_var_info(var_info)
+                    noun_name = getattr(ng, '_noun_name', None)
+                    if noun_name:
+                        self._symbol_scope[noun_name] = body_syms
                     body = ng(body_syms)
                     scope = _apply_to_vars(d, head_syms)
                     result = Implication(scope, body)
@@ -1190,6 +1193,20 @@ class SquallTransformer(Transformer):
                 noun_name = getattr(ng, '_noun_name', None)
                 if noun_name and noun_name in self._symbol_scope:
                     x = self._symbol_scope[noun_name]
+                    if isinstance(x, tuple):
+                        # Anaphora resolution for a multi-dimensional noun
+                        # (e.g. "the Voxel" referring back to "every Voxel in
+                        # 3D").  The scope entry is a tuple of symbols
+                        # (x₀, x₁, x₂).  The continuation d may be a
+                        # single-arg lambda (e.g. lambda obj:
+                        # verb(subject, obj)), so calling d(t0, t1, t2)
+                        # would raise TypeError.  We call d with the first
+                        # variable, then spread the rest into the resulting
+                        # FunctionApplication.
+                        result = d(x[0])
+                        if len(x) > 1 and isinstance(result, FunctionApplication):
+                            result = result.functor(*result.args, *x[1:])
+                        return result
                     return d(x)
 
                 # Special handling for aggregation ng1 — mirrors det_every.
@@ -2198,7 +2215,17 @@ class SquallTransformer(Transformer):
     # ---- Dimension / Aggregation ----
 
     def app_dimension(self, args):
-        return None
+        """Handle ``in ND`` dimension annotations (e.g. ``in 3D``).
+
+        Returns a tuple of *n* fresh symbols so that ``ng1_noun`` stores it
+        as ``_var_info`` and downstream determiner handlers create multi-
+        argument predicate calls (e.g. ``Voxel in 3D`` → ``voxel(x₀, x₁, x₂)``),
+        matching the semantics of the explicit tuple form
+        ``Voxel (?x; ?y; ?z)``.
+        """
+        number = args[0]
+        n = int(number.value) if hasattr(number, 'value') else int(number)
+        return tuple(Symbol.fresh() for _ in range(n))
 
     def app_label(self, args):
         label = args[0]

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -993,11 +993,49 @@ def test_anaphora_the_noun_with_nd_annotation_resolves():
 
     voxel_atom = next(a for a in body_atoms if a.functor == Symbol("voxel"))
     reports_atom = next(a for a in body_atoms if a.functor == Symbol("reports"))
-    voxel_var = voxel_atom.args[0]
-    reports_voxel_var = reports_atom.args[1]
-    assert voxel_var == reports_voxel_var, (
-        f"Expected ND anaphora resolution: voxel var {voxel_var} != reports arg {reports_voxel_var}"
+    assert len(voxel_atom.args) == 3, (
+        f"Expected voxel to have 3 args (3D), got {len(voxel_atom.args)}: {voxel_atom.args}"
     )
+    assert len(reports_atom.args) == 4, (
+        f"Expected reports to have 4 args (study + 3 voxel coords), "
+        f"got {len(reports_atom.args)}: {reports_atom.args}"
+    )
+    voxel_vars = voxel_atom.args
+    reports_voxel_vars = reports_atom.args[1:]
+    assert voxel_vars == reports_voxel_vars, (
+        f"Expected ND anaphora resolution: voxel vars {voxel_vars} "
+        f"!= reports voxel args {reports_voxel_vars}"
+    )
+
+
+def test_nd_annotation_and_tuple_label_equivalent_arity():
+    """'Voxel in 3D' and 'Voxel (?x; ?y; ?z)' must produce the same predicate arities."""
+    from neurolang.frontend.datalog.squall_syntax_lark import parser as p
+
+    r1 = p("obtain every Voxel (?x; ?y; ?z) that a Study reported.")
+    r2 = p("obtain every Voxel in 3D that a Study reported.")
+
+    def _collect_arities(expr, out=None):
+        if out is None:
+            out = {}
+        if hasattr(expr, 'functor') and hasattr(expr, 'args'):
+            name = expr.functor.name if isinstance(expr.functor, Symbol) else str(expr.functor)
+            out.setdefault(name, set()).add(len(expr.args))
+        if hasattr(expr, 'formulas'):
+            for f in expr.formulas:
+                _collect_arities(f, out)
+        if hasattr(expr, 'head') and hasattr(expr, 'body'):
+            _collect_arities(expr.head, out)
+            _collect_arities(expr.body, out)
+        return out
+
+    arities1 = _collect_arities(r1)
+    arities2 = _collect_arities(r2)
+
+    assert arities1['voxel'] == {3}, f"Tuple form: voxel arity = {arities1.get('voxel')}"
+    assert arities2['voxel'] == {3}, f"ND form: voxel arity = {arities2.get('voxel')}"
+    assert arities1['reported'] == {4}, f"Tuple form: reported arity = {arities1.get('reported')}"
+    assert arities2['reported'] == {4}, f"ND form: reported arity = {arities2.get('reported')}"
 
 
 def test_anaphora_unbound_noun_creates_existential():


### PR DESCRIPTION
## Problem

Two SQUALL queries that should translate equivalently produced different IR:

1. `obtain every Voxel (?x; ?y; ?z) that a Study reported.` → `voxel(x, y, z)` (3 args ✓)
2. `obtain every Voxel in 3D that a Study reported.` → `voxel(x₀)` (1 arg ✗)

The `in 3D` dimension annotation was silently discarded by `app_dimension` returning `None`, and downstream anaphora resolution also failed for multi-dimensional nouns.

## Fixes

### 1. `app_dimension` — was a no-op, now generates fresh variables

```python
# Before
def app_dimension(self, args):
    return None

# After — returns a tuple of n fresh Symbols, matching tuple-label semantics
def app_dimension(self, args):
    number = args[0]
    n = int(number.value) if hasattr(number, "value") else int(number)
    return tuple(Symbol.fresh() for _ in range(n))
```

`"Voxel in 3D"` now produces `voxel(f₀, f₁, f₂)` — structurally identical to `"Voxel (?x; ?y; ?z)"` except with fresh variables instead of user-named ones.

### 2. `det_every` — register multi-dimensional nouns in `_symbol_scope`

When `var_info` is a tuple, `det_every` was not storing the noun name in `_symbol_scope`, preventing `"the Voxel"` anaphora from resolving.

### 3. `det_the` — spread tuple scope entries into verb arguments

When `"the Voxel"` resolves to a tuple `(f₀, f₁, f₂)` from scope, the continuation `d` (e.g. `lambda obj: reports(study, obj)`) only accepts one argument. The fix calls `d(f₀)` then appends the remaining variables to the resulting `FunctionApplication`.

## Test changes

- Updated `test_anaphora_the_noun_with_nd_annotation_resolves` to verify 3-arg `voxel` and 4-arg `reports` with shared variables
- Added `test_nd_annotation_and_tuple_label_equivalent_arity` asserting both forms produce identical predicate arities

All 52 tests pass (51 existing + 1 new).

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)