### PR TITLE
fix: replace broken Codacy/CodeClimate badges with GH Actions-native …

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -41,10 +43,18 @@ jobs:
       timeout-minutes: 30
       if: matrix.python-version == '3.12'
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+    - name: Generate coverage badge
+      run: |
+        pip install coverage-badge
+        mkdir -p badges
+        coverage-badge -o badges/coverage.svg -f
+      if: github.ref == 'refs/heads/master' && matrix.python-version == '3.12'
+
+    - name: Publish badge to gh-pages
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        file: ./coverage.xml
-        flags: unittest
-        name: codecov-${{ matrix.python-version }}
-      if: matrix.python-version == '3.12'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./badges
+        destination_dir: ./
+        keep_files: false
+      if: github.ref == 'refs/heads/master' && matrix.python-version == '3.12'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NeuroLang
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/a39fccb376b74d3aa152d3d522030eb7)](https://app.codacy.com/gh/NeuroLang/NeuroLang/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/a39fccb376b74d3aa152d3d522030eb7)](https://app.codacy.com/gh/NeuroLang/NeuroLang/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
-
-[![Maintainability](https://api.codeclimate.com/v1/badges/dc08b264f2be98d9a9e2/maintainability)](https://codeclimate.com/repos/5d2c5d18aaf970014e004cd8/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/dc08b264f2be98d9a9e2/test_coverage)](https://codeclimate.com/repos/5d2c5d18aaf970014e004cd8/test_coverage)
+[![Tests](https://github.com/NeuroLang/NeuroLang/actions/workflows/tests.yml/badge.svg)](https://github.com/NeuroLang/NeuroLang/actions/workflows/tests.yml)
+[![Coverage](https://raw.githubusercontent.com/NeuroLang/NeuroLang/gh-pages/coverage.svg)](https://github.com/NeuroLang/NeuroLang/actions/workflows/tests.yml)
+[![PyPI](https://img.shields.io/pypi/v/neurolang.svg)](https://pypi.org/project/neurolang/)
+[![Python](https://img.shields.io/pypi/pyversions/neurolang.svg)](https://pypi.org/project/neurolang/)
 
 
 Neurolang enables the analysis of NeuroImaging data through probabilistic logic programming. It seamlessly allow to combine, images, databases, and ontologies within a single framework.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage](https://raw.githubusercontent.com/NeuroLang/NeuroLang/gh-pages/coverage.svg)](https://github.com/NeuroLang/NeuroLang/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/neurolang.svg)](https://pypi.org/project/neurolang/)
 [![Python](https://img.shields.io/pypi/pyversions/neurolang.svg)](https://pypi.org/project/neurolang/)
+[![Code style](https://img.shields.io/badge/code%20style-flake8-000000.svg)](https://github.com/PyCQA/flake8)
 
 
 Neurolang enables the analysis of NeuroImaging data through probabilistic logic programming. It seamlessly allow to combine, images, databases, and ontologies within a single framework.


### PR DESCRIPTION
…badges

- Remove external Codacy (grade + coverage) and CodeClimate (maintainability + coverage) badges
- Add Tests badge via GitHub Actions workflow badge SVG
- Add Coverage badge generated from pytest-cov via coverage-badge, published to gh-pages
- Add Python versions badge via shields.io static badge
- Replace Codecov upload in CI with badge generation + gh-pages publish step
- Add contents: write permission for gh-pages push