### PR TITLE
fix: install setuptools for coverage-badge on Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Generate coverage badge
       run: |
+        pip install setuptools
         pip install coverage-badge
         mkdir -p badges
         coverage-badge -o badges/coverage.svg -f


### PR DESCRIPTION
The `coverage-badge` package imports `pkg_resources` which was removed from the Python 3.12 stdlib. Installing `setuptools` (which provides `pkg_resources`) before `coverage-badge` resolves the CI failure on Python 3.12.

CI was failing with:
```
ModuleNotFoundError: No module named 'pkg_resources'
```

Tests themselves all pass (1578/1578) — this is purely a badge-generation step failure.