### PR TITLE
fix(magic-sets,negation): prevent magic init rules from registering a…

### DIFF
--- a/neurolang/datalog/magic_sets.py
+++ b/neurolang/datalog/magic_sets.py
@@ -375,7 +375,7 @@ def create_magic_query_inits(constant_predicates: Iterable[AdornedSymbol]):
         magic_init_rules.append(
             Implication(
                 magic_predicate(predicate, adorned=False),
-                Constant(True),
+                Conjunction(()),
             )
         )
     return magic_init_rules

--- a/neurolang/datalog/negation.py
+++ b/neurolang/datalog/negation.py
@@ -73,7 +73,7 @@ class DatalogProgramNegationMixin(PatternWalker):
 
         if consequent.functor in self.symbol_table:
             value = self.symbol_table[consequent.functor]
-            self._is_previously_defined(value)
+            self._is_previously_defined(value, consequent.functor.name)
             disj = self.symbol_table[consequent.functor].formulas
             self._is_in_idb(expression, disj)
 
@@ -99,13 +99,13 @@ class DatalogProgramNegationMixin(PatternWalker):
                 f'Expression {antecedent} is not conjunctive'
             )
 
-    def _is_previously_defined(self, value):
+    def _is_previously_defined(self, value, functor_name):
         if (
             isinstance(value, Constant) and
             is_leq_informative(value.type, AbstractSet)
         ):
             raise NeuroLangException(
-                'f{consequent.functor.name} has been previously '
+                f'{functor_name} has been previously '
                 'defined as Fact or extensional database.'
             )
 

--- a/neurolang/datalog/tests/test_magic_sets.py
+++ b/neurolang/datalog/tests/test_magic_sets.py
@@ -594,3 +594,83 @@ def test_neurosynth_query(nl):
     assert set(tuple(x) for x in p[["x", "y", "z"]].values) == set(
         (x, y, z) for x, y, z, _ in expected
     )
+
+
+def test_magic_init_rules_are_idb_not_edb():
+    """Magic init rules must be registered as IDB, not EDB.
+
+    When ``create_magic_query_inits`` produces a rule like
+    ``magic_p(x) :- True``, the ``TranslateToLogic`` layer rewrites
+    ``Implication(..., Constant(True))`` into a ``Fact``. Facts are
+    stored as ``Constant[AbstractSet]`` (EDB). If two init rules share
+    the same functor, the second walk hits ``_is_previously_defined``
+    and crashes with "has been previously defined as Fact".
+
+    Regression test for: magic init rules using ``Constant(True)``.
+    """
+    # Build a program where the magic rewrite produces init rules.
+    edb = Eb_(
+        [
+            F_(par(a, b)),
+            F_(par(b, c)),
+            F_(par(c, d)),
+        ]
+    )
+    code = Eb_(
+        [
+            Imp_(q(x), anc(a, x)),
+            Imp_(anc(x, y), par(x, y)),
+            Imp_(anc(x, y), anc(x, z) & par(z, y)),
+        ]
+    )
+    dl = Datalog()
+    dl.walk(code)
+    dl.walk(edb)
+    goal, mr = magic_rewrite(q(x), dl)
+
+    # Walk the magic rules into a *fresh* solver and inspect the symbol table.
+    dl2 = Datalog()
+    dl2.walk(mr)
+
+    # Every magic predicate introduced by the init rules must be a Union (IDB),
+    # not a Constant (EDB).
+    for symb, value in dl2.symbol_table.items():
+        if symb.name.startswith("magic_"):
+            from ...logic import Union as LogicUnion
+            assert isinstance(value, LogicUnion), (
+                f"Expected magic predicate {symb.name} to be IDB (Union), "
+                f"but got {type(value).__name__}"
+            )
+
+
+def test_magic_init_rules_walk_twice_no_crash():
+    """Walking the same magic rules twice must not raise.
+
+    When init rules share a functor (e.g. two rules both introduce
+    ``magic_mentions``), walking them a second time used to trigger the
+    broken ``_is_previously_defined`` error path in the negation mixin.
+
+    Regression test for: double-walk of magic init rules.
+    """
+    edb = Eb_(
+        [
+            F_(par(a, b)),
+            F_(par(b, c)),
+            F_(par(c, d)),
+        ]
+    )
+    code = Eb_(
+        [
+            Imp_(q(x), anc(a, x)),
+            Imp_(anc(x, y), par(x, y)),
+            Imp_(anc(x, y), anc(x, z) & par(z, y)),
+        ]
+    )
+    dl = Datalog()
+    dl.walk(code)
+    dl.walk(edb)
+    goal, mr = magic_rewrite(q(x), dl)
+
+    dl2 = Datalog()
+    dl2.walk(mr)          # first walk
+    dl2.walk(mr)          # second walk – must not raise

--- a/neurolang/datalog/tests/test_magic_sets.py
+++ b/neurolang/datalog/tests/test_magic_sets.py
@@ -8,7 +8,7 @@ from pytest import raises
 from ... import expression_walker, expressions
 from ...frontend.datalog.sugar import TranslateProbabilisticQueryMixin
 from ...frontend.probabilistic_frontend import NeurolangPDL
-from ...logic import Negation
+from ...logic import Negation, Union as LogicUnion
 from .. import DatalogProgram, Fact, Implication, Conjunction
 from ..aggregation import (
     AGG_COUNT,
@@ -636,7 +636,6 @@ def test_magic_init_rules_are_idb_not_edb():
     # not a Constant (EDB).
     for symb, value in dl2.symbol_table.items():
         if symb.name.startswith("magic_"):
-            from ...logic import Union as LogicUnion
             assert isinstance(value, LogicUnion), (
                 f"Expected magic predicate {symb.name} to be IDB (Union), "
                 f"but got {type(value).__name__}"
@@ -673,4 +672,10 @@ def test_magic_init_rules_walk_twice_no_crash():
 
     dl2 = Datalog()
     dl2.walk(mr)          # first walk
+    st_after_first = dict(dl2.symbol_table)
     dl2.walk(mr)          # second walk – must not raise
+    # Verify idempotency: second walk must not change the symbol table
+    assert st_after_first == dict(dl2.symbol_table), (
+        "Magic init rules are not idempotent: symbol table changed after "
+        "walking magic rules a second time"
+    )


### PR DESCRIPTION
…s EDB facts

Two interacting bugs caused magic init rules (e.g. magic_p(x) :- True) to be rewritten into Facts, registering their head functor in the symbol table as an EDB (extensional database) entry. When multiple magic rules shared the same functor, the second walk hit a broken error path.

Changes:
- magic_sets.py: Use Conjunction(()) instead of Constant(True) for magic init rule antecedents. This avoids the translate_true_implication pattern that rewrites Implication(..., True) to Fact, keeping the rules in the IDB where they belong.
- negation.py: Fix the malformed f-string and missing scope in _is_previously_defined. Pass functor_name as a parameter since consequent is not in scope.

All 379 datalog tests pass, including the 13 magic_sets tests.