### PR TITLE
fix(squall): allow Probability and Value as nouns in compound quantifiers

### DIFF
--- a/neurolang/frontend/datalog/neurolang_natural.lark
+++ b/neurolang/frontend/datalog/neurolang_natural.lark
@@ -187,8 +187,7 @@ adj1 : intransitive
 adjn : transitive_multiple
 
 noun1 : intransitive
-      | DIM_PROBABILITY
-      | DIM_VALUE
+     | dimension_noun
 noun2 : transitive
 
 verb1 : intransitive

--- a/neurolang/frontend/datalog/neurolang_natural.lark
+++ b/neurolang/frontend/datalog/neurolang_natural.lark
@@ -187,7 +187,8 @@ adj1 : intransitive
 adjn : transitive_multiple
 
 noun1 : intransitive
-     | dimension_noun
+     | DIM_PROBABILITY
+     | DIM_VALUE
 noun2 : transitive
 
 verb1 : intransitive

--- a/neurolang/frontend/datalog/neurolang_natural.lark
+++ b/neurolang/frontend/datalog/neurolang_natural.lark
@@ -51,6 +51,7 @@ rule_body2 : quant_list _WHERE s                    -> rule_body2_where
 
 quant_list : quant_clause                           -> quant_list_single
            | quant_list _AND quant_clause            -> quant_list_rec
+           | quant_list quant_clause                 -> quant_list_rec
 
 quant_clause : _FOR _EVERY ng1 [ app ]               -> quant_clause_ng1
              | _FOR _EVERY npc{THE}                  -> quant_clause_npc

--- a/neurolang/frontend/datalog/neurolang_natural.lark
+++ b/neurolang/frontend/datalog/neurolang_natural.lark
@@ -98,12 +98,9 @@ ng2 : noun2 [ app ]
 
 
 
-dimension_noun : DIM_PROBABILITY | DIM_VALUE
-
-app : _IN number"D" _WITH dimension_noun -> app_dimension_with
-    | _IN number"D" _WITH intransitive -> app_dimension_with
+app : _IN number"D" _WITH intransitive -> app_dimension_with
     | _IN number"D" -> app_dimension
-    | _WITH dimension_noun -> app_dimension_only
+    | _WITH intransitive -> app_dimension_only
     | label          -> app_label
 
 dims : dim                    -> dims_base
@@ -113,7 +110,7 @@ dim : (_PER | _FOR _EACH) ng2                         -> dim_ng2
     | (_PER | _FOR _EACH) npc{THE} ("," npc{THE})+    -> dim_npc_list
     | (_PER | _FOR _EACH) npc{THE}                    -> dim_npc
     | agg_func _OF npc{THE}                            -> dim_agg
-    | _PER dimension_noun                              -> dim_keyword
+    | _PER intransitive                              -> dim_keyword
 
 agg_func : AGG_FUNC
 AGG_FUNC : "count" | "sum" | "max" | "min" | "average"
@@ -187,8 +184,6 @@ adj1 : intransitive
 adjn : transitive_multiple
 
 noun1 : intransitive
-     | DIM_PROBABILITY
-     | DIM_VALUE
 noun2 : transitive
 
 verb1 : intransitive
@@ -350,12 +345,9 @@ _WHO : "who"
 _WHOM : "whom"
 _WHOSE : "whose"
 
-DIM_PROBABILITY : "Probability"
-DIM_VALUE : "Value"
-
 LOWER_NAME : /(?!(\b(a|all|an|and|are|as|average|by|choice|conditioned|count|define|defines|do|does|did|each|equiprobable|every|equal|from|for|greater|given|inferred|holds|likely|obtain|has|hasn't|have|had|if|in|is|isn't|lower|max|min|no|not|of|or|over|per|probability|probably|some|such|sum|than|that|the|then|there|to|was|were|when|where|which|with|who|whom|whose)\b))//[a-z_]\w*/
-UPPER_NAME : /(?!(\b(a|all|an|and|are|as|average|by|choice|conditioned|count|define|defines|do|does|did|each|equiprobable|every|equal|from|for|greater|given|inferred|holds|likely|obtain|has|hasn't|have|had|if|in|is|isn't|lower|max|min|no|not|of|or|over|per|probability|probably|some|such|sum|than|that|the|then|there|to|was|were|when|where|which|with|who|whom|whose|Probability|Value)\b))//[A-Z]\w*/
-NAME : /(?!(\b(a|all|an|and|are|as|average|by|choice|conditioned|count|define|defines|do|does|did|each|equiprobable|every|equal|from|for|greater|given|inferred|holds|likely|obtain|has|hasn't|have|had|if|in|is|isn't|lower|max|min|no|not|of|or|over|per|probability|probably|some|such|sum|than|that|the|then|there|to|was|were|when|where|which|with|who|whom|whose|Probability|Value)\b))//[a-zA-Z_]\w*/
+UPPER_NAME : /(?!(\b(a|all|an|and|are|as|average|by|choice|conditioned|count|define|defines|do|does|did|each|equiprobable|every|equal|from|for|greater|given|inferred|holds|likely|obtain|has|hasn't|have|had|if|in|is|isn't|lower|max|min|no|not|of|or|over|per|probability|probably|some|such|sum|than|that|the|then|there|to|was|were|when|where|which|with|who|whom|whose)\b))//[A-Z]\w*/
+NAME : /(?!(\b(a|all|an|and|are|as|average|by|choice|conditioned|count|define|defines|do|does|did|each|equiprobable|every|equal|from|for|greater|given|inferred|holds|likely|obtain|has|hasn't|have|had|if|in|is|isn't|lower|max|min|no|not|of|or|over|per|probability|probably|some|such|sum|than|that|the|then|there|to|was|were|when|where|which|with|who|whom|whose)\b))//[a-zA-Z_]\w*/
 UPPER_NAME_QUOTED : /`[A-Z][^`]*`/
 LOWER_NAME_QUOTED : /`[a-z][^`]*`/
 STRING : /[^']+/

--- a/neurolang/frontend/datalog/squall.py
+++ b/neurolang/frontend/datalog/squall.py
@@ -197,7 +197,7 @@ class StripDimensionTypePredicatesMixin(PatternWalker):
 
     @add_match(FunctionApplication(Symbol, (Expression,)))
     def replace_dimension_type_atom(self, fa):
-        if fa.functor.name not in self.__class__.dimension_type_predicate_names:
+        if fa.functor.name not in self.dimension_type_predicate_names:
             return fa
         return Constant(True)
 

--- a/neurolang/frontend/datalog/squall.py
+++ b/neurolang/frontend/datalog/squall.py
@@ -6,7 +6,7 @@ and normalizes quantifier expressions produced by the SQUALL parser.
 """
 from ...datalog.expressions import AggregationApplication as _AggApp
 from ...expression_walker import ExpressionWalker, PatternWalker, add_match
-from ...expressions import Constant, FunctionApplication, Query
+from ...expressions import Constant, FunctionApplication, Query, Symbol
 from ...logic import (
     Conjunction,
     ExistentialPredicate,
@@ -169,3 +169,56 @@ class LogicSimplifier(
         if new_args != expression.args:
             return expression.functor(*new_args)
         return expression
+
+
+_DIMENSION_TYPE_PREDICATE_NAMES = frozenset({
+    "probability",
+    "value",
+})
+
+
+class StripDimensionTypePredicatesMixin(PatternWalker):
+    """Strips dimension-type atoms (probability/1, value/1) from rule bodies.
+
+    Probability and Value are type annotations in SQUALL — they introduce a
+    variable into scope without representing a database predicate. The SQUALL
+    parser generates ``probability(v)`` / ``value(v)`` atoms from quantifiers
+    like ``for every Probability``. This mixin removes those atoms from rule
+    bodies so they never reach the Datalog engine.
+
+    Must be placed in the frontend solver MRO after any expression-simplifying
+    walkers but before the Datalog program solver (e.g.,
+    ``TranslateToLogicWithAggregation``).
+    """
+
+    @add_match(
+        Conjunction,
+        lambda conjunction: any(
+            isinstance(f, FunctionApplication)
+            and isinstance(f.functor, Symbol)
+            and f.functor.name in _DIMENSION_TYPE_PREDICATE_NAMES
+            and len(f.args) == 1
+            for f in conjunction.formulas
+        ),
+    )
+    def strip_from_conjunction(self, conjunction):
+        filtered = tuple(
+            f for f in conjunction.formulas
+            if not self._is_dimension_type_atom(f)
+        )
+        if len(filtered) == 0:
+            return Constant(True)
+        if len(filtered) == 1:
+            return self.walk(filtered[0])
+        if len(filtered) == len(conjunction.formulas):
+            return conjunction
+        return Conjunction(filtered)
+
+    @staticmethod
+    def _is_dimension_type_atom(expr):
+        return (
+            isinstance(expr, FunctionApplication)
+            and isinstance(expr.functor, Symbol)
+            and expr.functor.name in _DIMENSION_TYPE_PREDICATE_NAMES
+            and len(expr.args) == 1
+        )

--- a/neurolang/frontend/datalog/squall.py
+++ b/neurolang/frontend/datalog/squall.py
@@ -178,47 +178,35 @@ _DIMENSION_TYPE_PREDICATE_NAMES = frozenset({
 
 
 class StripDimensionTypePredicatesMixin(PatternWalker):
-    """Strips dimension-type atoms (probability/1, value/1) from rule bodies.
+    """Replaces dimension-type atoms (probability/1, value/1) with Constant(True).
 
     Probability and Value are type annotations in SQUALL — they introduce a
-    variable into scope without representing a database predicate. The SQUALL
-    parser generates ``probability(v)`` / ``value(v)`` atoms from quantifiers
-    like ``for every Probability``. This mixin removes those atoms from rule
-    bodies so they never reach the Datalog engine.
+    variable into scope without representing a database predicate. This mixin
+    replaces their atoms with Constant(True) so they are simplified away by
+    RemoveTrivialOperationsMixin or ``LogicSimplifier.remove_true_from_conjunction``.
 
-    Must be placed in the frontend solver MRO after any expression-simplifying
-    walkers but before the Datalog program solver (e.g.,
-    ``TranslateToLogicWithAggregation``).
+    Extend with a different predicate set by subclassing and defining
+    ``dimension_type_predicate_names`` on the subclass::
+
+        class MyMixin(StripDimensionTypePredicatesMixin):
+            dimension_type_predicate_names = frozenset({
+                "probability", "value", "intensity",
+            })
+
+    The module-level ``_DIMENSION_TYPE_PREDICATE_NAMES`` is the default used
+    in the guard lambda. Subclasses override the attribute but the lambda
+    still matches structurally; the handler checks the instance attribute.
     """
 
+    dimension_type_predicate_names = _DIMENSION_TYPE_PREDICATE_NAMES
+
     @add_match(
-        Conjunction,
-        lambda conjunction: any(
-            isinstance(f, FunctionApplication)
-            and isinstance(f.functor, Symbol)
-            and f.functor.name in _DIMENSION_TYPE_PREDICATE_NAMES
-            and len(f.args) == 1
-            for f in conjunction.formulas
+        FunctionApplication,
+        lambda fa: (
+            isinstance(fa.functor, Symbol)
+            and fa.functor.name in _DIMENSION_TYPE_PREDICATE_NAMES
+            and len(fa.args) == 1
         ),
     )
-    def strip_from_conjunction(self, conjunction):
-        filtered = tuple(
-            f for f in conjunction.formulas
-            if not self._is_dimension_type_atom(f)
-        )
-        if len(filtered) == 0:
-            return Constant(True)
-        if len(filtered) == 1:
-            return self.walk(filtered[0])
-        if len(filtered) == len(conjunction.formulas):
-            return conjunction
-        return Conjunction(filtered)
-
-    @staticmethod
-    def _is_dimension_type_atom(expr):
-        return (
-            isinstance(expr, FunctionApplication)
-            and isinstance(expr.functor, Symbol)
-            and expr.functor.name in _DIMENSION_TYPE_PREDICATE_NAMES
-            and len(expr.args) == 1
-        )
+    def replace_dimension_type_atom(self, fa):
+        return Constant(True)

--- a/neurolang/frontend/datalog/squall.py
+++ b/neurolang/frontend/datalog/squall.py
@@ -6,7 +6,7 @@ and normalizes quantifier expressions produced by the SQUALL parser.
 """
 from ...datalog.expressions import AggregationApplication as _AggApp
 from ...expression_walker import ExpressionWalker, PatternWalker, add_match
-from ...expressions import Constant, FunctionApplication, Query, Symbol
+from ...expressions import Constant, Expression, FunctionApplication, Query, Symbol
 from ...logic import (
     Conjunction,
     ExistentialPredicate,
@@ -185,28 +185,58 @@ class StripDimensionTypePredicatesMixin(PatternWalker):
     replaces their atoms with Constant(True) so they are simplified away by
     RemoveTrivialOperationsMixin or ``LogicSimplifier.remove_true_from_conjunction``.
 
-    Extend with a different predicate set by subclassing and defining
-    ``dimension_type_predicate_names`` on the subclass::
+    Override ``dimension_type_predicate_names`` on a subclass for custom names::
 
         class MyMixin(StripDimensionTypePredicatesMixin):
-            dimension_type_predicate_names = frozenset({
-                "probability", "value", "intensity",
-            })
+            dimension_type_predicate_names = {"probability", "value", "intensity"}
 
-    The module-level ``_DIMENSION_TYPE_PREDICATE_NAMES`` is the default used
-    in the guard lambda. Subclasses override the attribute but the lambda
-    still matches structurally; the handler checks the instance attribute.
+    Use ``make_dimension_type_stripper()`` to create one from engine YAML config.
     """
 
     dimension_type_predicate_names = _DIMENSION_TYPE_PREDICATE_NAMES
 
-    @add_match(
-        FunctionApplication,
-        lambda fa: (
-            isinstance(fa.functor, Symbol)
-            and fa.functor.name in _DIMENSION_TYPE_PREDICATE_NAMES
-            and len(fa.args) == 1
-        ),
-    )
+    @add_match(FunctionApplication(Symbol, (Expression,)))
     def replace_dimension_type_atom(self, fa):
+        if fa.functor.name not in self.__class__.dimension_type_predicate_names:
+            return fa
         return Constant(True)
+
+
+def make_dimension_type_stripper(predicate_names=None):
+    """Create a StripDimensionTypePredicatesMixin subclass with custom names.
+
+    Parameters
+    ----------
+    predicate_names : iterable of str, optional
+        Predicate names to treat as dimension-type annotations.
+        Defaults to ``{"probability", "value"}``.
+
+    Returns
+    -------
+    type
+        A ``StripDimensionTypePredicatesMixin`` subclass that replaces
+        only *predicate_names* atoms with ``Constant(True)``.
+
+    Examples
+    --------
+    Used from engine YAML config::
+
+        from neurolang.frontend.datalog.squall import (
+            make_dimension_type_stripper,
+        )
+
+        Mixin = make_dimension_type_stripper(
+            ["probability", "value", "intensity"]
+        )
+        # Then insert Mixin into the frontend solver MRO
+    """
+    if predicate_names is not None:
+        predicate_names = frozenset(predicate_names)
+    else:
+        predicate_names = _DIMENSION_TYPE_PREDICATE_NAMES
+
+    class _Stripper(StripDimensionTypePredicatesMixin):
+        dimension_type_predicate_names = predicate_names
+
+    _Stripper.__qualname__ = "StripDimensionTypePredicatesMixin"
+    return _Stripper

--- a/neurolang/frontend/datalog/squall_syntax_lark.py
+++ b/neurolang/frontend/datalog/squall_syntax_lark.py
@@ -914,7 +914,10 @@ class SquallTransformer(Transformer):
         type_preds = []
         for clause in quant_list:
             _, (var, type_pred) = clause
-            head_vars.append(var)
+            if isinstance(var, tuple):
+                head_vars.extend(var)
+            else:
+                head_vars.append(var)
             type_preds.append(type_pred)
 
         body_parts = type_preds + [where_sentence]

--- a/neurolang/frontend/datalog/squall_syntax_lark.py
+++ b/neurolang/frontend/datalog/squall_syntax_lark.py
@@ -287,6 +287,12 @@ def _resolve_var_info(var_info):
     return var_info, [var_info]
 
 
+_DIMENSION_NOUN_NAMES = frozenset({
+    Symbol("probability"),
+    Symbol("value"),
+})
+
+
 class SquallTransformer(Transformer):
 
     """Transforms a SQUALL parse tree into NeuroLang logical expressions.
@@ -872,6 +878,9 @@ class SquallTransformer(Transformer):
         """Handle `for every Region [?r]` in a compound quantifier list.
 
         Returns `('_quant_clause', (var, type_predicate))`.
+        type_predicate may be None for type-annotation nouns (Probability,
+        Value) that introduce a variable into scope without generating a
+        body predicate.
         """
         items = [a for a in args if a is not None]
         ng1 = items[0]
@@ -891,7 +900,11 @@ class SquallTransformer(Transformer):
             self._symbol_scope[noun_name] = body_args
             self._has_rule_scope = True
 
-        type_predicate = ng1(body_args)
+        # Dimension nouns (Probability, Value) are type annotations that
+        # introduce a variable without generating a body predicate.
+        type_predicate = None
+        if noun_name and noun_name not in _DIMENSION_NOUN_NAMES:
+            type_predicate = ng1(body_args)
         return ('_quant_clause', (body_args, type_predicate))
 
     def quant_list_single(self, args):
@@ -921,7 +934,7 @@ class SquallTransformer(Transformer):
             type_preds.append(type_pred)
 
         body_parts = type_preds + [where_sentence]
-        body_formula = Conjunction(tuple(body_parts))
+        body_formula = Conjunction(tuple(p for p in body_parts if p is not None))
         return ('_rule_body2', (head_vars, body_formula))
 
     def rule_body1_cond_prior(self, args):

--- a/neurolang/frontend/datalog/squall_syntax_lark.py
+++ b/neurolang/frontend/datalog/squall_syntax_lark.py
@@ -1216,8 +1216,8 @@ class SquallTransformer(Transformer):
                         # path: ng(x) type predicate + continuation applied
                         # via try/except (multi-arg for capturing_cont,
                         # single-arg + FunctionApplication spread for verb
-                        # lambdas).  Wrap in AnaphoraPredicate / existential
-                        # chain so aggregation can strip them.
+                        # lambdas).  The variables in x are free head
+                        # variables, so they must NOT be existentially bound.
                         body = ng(x)
                         try:
                             scope = d(*x)
@@ -1226,8 +1226,6 @@ class SquallTransformer(Transformer):
                             if len(x) > 1 and isinstance(scope, FunctionApplication):
                                 scope = scope.functor(*scope.args, *x[1:])
                         result = Conjunction((body, scope))
-                        for sym in x:
-                            result = ExistentialPredicate(sym, result)
                         return result
                     return d(x)
 

--- a/neurolang/frontend/datalog/squall_syntax_lark.py
+++ b/neurolang/frontend/datalog/squall_syntax_lark.py
@@ -2354,12 +2354,6 @@ class SquallTransformer(Transformer):
             self._symbol_scope[dim_noun.name] = result[-1]
         return result
 
-    def dimension_noun(self, args):
-        """Convert a dimension keyword token to its lowercase Symbol form."""
-        token = args[0]
-        name = token.value if hasattr(token, 'value') else str(token)
-        return Symbol(name.lower())
-
     def app_label(self, args):
         label = args[0]
         if callable(label) and not isinstance(label, (Symbol, Constant)):

--- a/neurolang/frontend/datalog/squall_syntax_lark.py
+++ b/neurolang/frontend/datalog/squall_syntax_lark.py
@@ -287,12 +287,6 @@ def _resolve_var_info(var_info):
     return var_info, [var_info]
 
 
-_DIMENSION_NOUN_NAMES = frozenset({
-    Symbol("probability"),
-    Symbol("value"),
-})
-
-
 class SquallTransformer(Transformer):
 
     """Transforms a SQUALL parse tree into NeuroLang logical expressions.
@@ -900,11 +894,11 @@ class SquallTransformer(Transformer):
             self._symbol_scope[noun_name] = body_args
             self._has_rule_scope = True
 
-        # Dimension nouns (Probability, Value) are type annotations that
-        # introduce a variable without generating a body predicate.
-        type_predicate = None
-        if noun_name and noun_name not in _DIMENSION_NOUN_NAMES:
-            type_predicate = ng1(body_args)
+        # Always generate the type predicate for the quantifier noun.
+        # Dimension nouns (Probability, Value) will generate probability/1
+        # or value/1 atoms, which are stripped by StripDimensionTypePredicatesMixin
+        # at the frontend level (before the Datalog engine processes them).
+        type_predicate = ng1(body_args)
         return ('_quant_clause', (body_args, type_predicate))
 
     def quant_list_single(self, args):

--- a/neurolang/frontend/datalog/tests/test_squall.py
+++ b/neurolang/frontend/datalog/tests/test_squall.py
@@ -1,0 +1,343 @@
+"""Tests for StripDimensionTypePredicatesMixin and make_dimension_type_stripper."""
+
+from ....datalog import Conjunction, Implication
+from ....expression_walker import ExpressionWalker, PatternWalker, add_match
+from ....expressions import Constant, Expression, FunctionApplication, Symbol
+from ..squall import (
+    StripDimensionTypePredicatesMixin,
+    _DIMENSION_TYPE_PREDICATE_NAMES,
+    make_dimension_type_stripper,
+)
+
+
+class _TestWalker(StripDimensionTypePredicatesMixin, ExpressionWalker):
+    """Composite walker for unit tests: mixin + ExpressionWalker fallback."""
+    pass
+
+
+def test_default_predicate_names():
+    """Default set contains exactly probability and value."""
+    assert _DIMENSION_TYPE_PREDICATE_NAMES == frozenset({"probability", "value"})
+
+
+class TestStripDimensionTypePredicatesMixin:
+    """Unit tests for direct walker instantiation."""
+
+    def test_replaces_dimension_type_atom(self):
+        """probability(v) is replaced with Constant(True)."""
+        walker = _TestWalker()
+        v = Symbol("v")
+        prob_atom = FunctionApplication(Symbol("probability"), (v,))
+        result = walker.walk(prob_atom)
+        assert result == Constant(True), (
+            f"Expected Constant(True), got {result}"
+        )
+
+    def test_replaces_value_atom(self):
+        """value(v) is replaced with Constant(True)."""
+        walker = _TestWalker()
+        v = Symbol("v")
+        value_atom = FunctionApplication(Symbol("value"), (v,))
+        result = walker.walk(value_atom)
+        assert result == Constant(True), (
+            f"Expected Constant(True), got {result}"
+        )
+
+    def test_leaves_non_dimension_predicate(self):
+        """voxel(s0, s1, s2) is left untouched."""
+        walker = _TestWalker()
+        s0, s1, s2 = Symbol("s0"), Symbol("s1"), Symbol("s2")
+        voxel_atom = FunctionApplication(Symbol("voxel"), (s0, s1, s2))
+        result = walker.walk(voxel_atom)
+        assert result is voxel_atom, (
+            f"Expected same object, got {result}"
+        )
+
+    def test_leaves_unknown_dimension_name(self):
+        """intensity(v) — not in default set — is left untouched."""
+        walker = _TestWalker()
+        v = Symbol("v")
+        intensity_atom = FunctionApplication(Symbol("intensity"), (v,))
+        result = walker.walk(intensity_atom)
+        assert result is intensity_atom, (
+            f"Expected same object, got {result}"
+        )
+
+    def test_leaves_non_predicate_function_application(self):
+        """Non-Symbol functor (e.g. Constant operator) is left untouched."""
+        from operator import eq
+        walker = _TestWalker()
+        v = Symbol("v")
+        expr = FunctionApplication(Constant(eq), (v, Constant(42)))
+        result = walker.walk(expr)
+        assert result is expr, (
+            f"Expected same object, got {result}"
+        )
+
+    def test_strips_from_conjunction(self):
+        """Conjunction with probability(v) has it removed via Constant(True)."""
+        walker = _TestWalker()
+        v = Symbol("v")
+        conj = Conjunction((
+            Symbol("voxel")(v, v, v),
+            Symbol("probability")(v),
+        ))
+        result = walker.walk(conj)
+        assert isinstance(result, Conjunction), (
+            f"Expected Conjunction, got {type(result)}: {result}"
+        )
+        # probability should be replaced by Constant(True), then
+        # the LogicSimplifier remove_true_from_conjunction would
+        # strip it — but since we just have StripDimensionTypePredicatesMixin
+        # + ExpressionWalker fallback, Constant(True) will be in formulas.
+        functors = {
+            f.functor.name
+            for f in result.formulas
+            if isinstance(f, FunctionApplication)
+        }
+        assert "probability" not in functors, (
+            f"probability should have been replaced; got {functors}"
+        )
+        assert "voxel" in functors
+
+
+class TestMakeDimensionTypeStripper:
+    """Tests for make_dimension_type_stripper factory."""
+
+    def test_default_predicates(self):
+        """No arguments uses default {'probability', 'value'}."""
+        Mixin = make_dimension_type_stripper()
+        assert issubclass(Mixin, StripDimensionTypePredicatesMixin)
+        assert Mixin.dimension_type_predicate_names == frozenset(
+            {"probability", "value"}
+        )
+
+    def test_custom_predicates(self):
+        """Custom names override the default set."""
+        Mixin = make_dimension_type_stripper(["intensity", "confidence"])
+
+        class _CustomWalker(Mixin, ExpressionWalker):
+            pass
+
+        walker = _CustomWalker()
+        v = Symbol("v")
+
+        # Custom names are replaced
+        intensity_atom = FunctionApplication(Symbol("intensity"), (v,))
+        result = walker.walk(intensity_atom)
+        assert result == Constant(True), (
+            f"Expected Constant(True) for intensity, got {result}"
+        )
+
+        # Default names are NOT replaced
+        prob_atom = FunctionApplication(Symbol("probability"), (v,))
+        result = walker.walk(prob_atom)
+        assert result is prob_atom, (
+            f"Expected untouched for probability, got {result}"
+        )
+
+    def test_qualified_name(self):
+        """Factory subclass has qualified name matching the base."""
+        Mixin = make_dimension_type_stripper()
+        assert Mixin.__qualname__ == "StripDimensionTypePredicatesMixin"
+
+    def test_override_via_subclass(self):
+        """Subclass overrides dimension_type_predicate_names correctly."""
+        class _CustomMixin(StripDimensionTypePredicatesMixin):
+            dimension_type_predicate_names = frozenset({"foo", "bar"})
+
+        class _CustomWalker(_CustomMixin, ExpressionWalker):
+            pass
+
+        walker = _CustomWalker()
+        v = Symbol("v")
+
+        foo_atom = FunctionApplication(Symbol("foo"), (v,))
+        assert walker.walk(foo_atom) == Constant(True)
+
+        prob_atom = FunctionApplication(Symbol("probability"), (v,))
+        assert walker.walk(prob_atom) is prob_atom
+
+
+class TestMROIntegration:
+    """MRO integration tests — walk through a full solver MRO."""
+
+    def test_strips_from_implication_deterministic(self):
+        """RegionFrontendDatalogSolver strips probability(v) from a Conjunction."""
+        from ....frontend.deterministic_frontend import (
+            RegionFrontendDatalogSolver,
+        )
+
+        solver = RegionFrontendDatalogSolver()
+        s0, s1, s2, s3, s4 = (
+            Symbol("s0"), Symbol("s1"), Symbol("s2"),
+            Symbol("s3"), Symbol("s4"),
+        )
+
+        conj = Conjunction((
+            Symbol("voxel")(s0, s1, s2),
+            Symbol("probability")(s3),
+            Symbol("schaefer_label")(s4),
+            Symbol("labels")(s4, s0, s1, s2),
+            Symbol("label_reports")(s4, s3),
+        ))
+
+        # Note: walking a full Implication through DatalogProgram returns
+        # the original expression (DatalogProgram.statement_intensional
+        # preserves the input). Walk the antecedent directly to verify
+        # the strip mixin runs inside the solver MRO.
+        result = solver.walk(conj)
+        assert isinstance(result, Conjunction), (
+            f"Expected Conjunction, got {type(result)}: {result}"
+        )
+
+        functors_in_body = {
+            f.functor.name
+            for f in result.formulas
+            if isinstance(f, FunctionApplication)
+        }
+        assert "probability" not in functors_in_body, (
+            f"probability should be stripped; got {functors_in_body}"
+        )
+        assert "voxel" in functors_in_body
+        assert "schaefer_label" in functors_in_body
+        assert "labels" in functors_in_body
+        assert "label_reports" in functors_in_body
+
+    def test_strips_from_implication_probabilistic(self):
+        """RegionFrontendCPLogicSolver strips probability(v) from a Conjunction."""
+        from ....frontend.probabilistic_frontend import (
+            RegionFrontendCPLogicSolver,
+        )
+
+        solver = RegionFrontendCPLogicSolver()
+        s0, s1, s2, s3, s4 = (
+            Symbol("s0"), Symbol("s1"), Symbol("s2"),
+            Symbol("s3"), Symbol("s4"),
+        )
+
+        conj = Conjunction((
+            Symbol("voxel")(s0, s1, s2),
+            Symbol("probability")(s3),
+            Symbol("schaefer_label")(s4),
+            Symbol("labels")(s4, s0, s1, s2),
+            Symbol("label_reports")(s4, s3),
+        ))
+
+        result = solver.walk(conj)
+        assert isinstance(result, Conjunction), (
+            f"Expected Conjunction, got {type(result)}: {result}"
+        )
+
+        functors_in_body = {
+            f.functor.name
+            for f in result.formulas
+            if isinstance(f, FunctionApplication)
+        }
+        assert "probability" not in functors_in_body, (
+            f"probability should be stripped; got {functors_in_body}"
+        )
+
+    def test_custom_mixin_in_mro(self):
+        """Custom mixin with non-default names works in a solver MRO."""
+        from ....frontend.deterministic_frontend import (
+            TranslateToLogicWithAggregation,
+            TranslateSSugarToSelectByColumn,
+            TranslateSelectByFirstColumn,
+            TranslateHeadConstantsToEqualities,
+            TypeResolutionMixin,
+            TranslateRegionDestroy,
+            Fol2DatalogMixin,
+            RegionSolver,
+            CommandsMixin,
+            NumpyFunctionsMixin,
+            DatalogWithAggregationMixin,
+            DatalogProgramNegationMixin,
+            DatalogProgram,
+            ExpressionBasicEvaluator,
+        )
+
+        CustomStripper = make_dimension_type_stripper(["intensity"])
+
+        class CustomSolver(
+            TranslateToLogicWithAggregation,
+            CustomStripper,
+            TranslateSSugarToSelectByColumn,
+            TranslateSelectByFirstColumn,
+            TranslateHeadConstantsToEqualities,
+            TypeResolutionMixin,
+            TranslateRegionDestroy,
+            Fol2DatalogMixin,
+            RegionSolver,
+            CommandsMixin,
+            NumpyFunctionsMixin,
+            DatalogWithAggregationMixin,
+            DatalogProgramNegationMixin,
+            DatalogProgram,
+            ExpressionBasicEvaluator,
+        ):
+            pass
+
+        solver = CustomSolver()
+        v = Symbol("v")
+        s = Symbol("s")
+
+        conj = Conjunction((
+            Symbol("voxel")(v, v, v),
+            Symbol("intensity")(v),
+            Symbol("probability")(s),
+        ))
+
+        result = solver.walk(conj)
+        assert isinstance(result, Conjunction), (
+            f"Expected Conjunction, got {type(result)}: {result}"
+        )
+
+        functors = {
+            f.functor.name
+            for f in result.formulas
+            if isinstance(f, FunctionApplication)
+        }
+        # 'intensity' was our custom dimension predicate — should be stripped
+        assert "intensity" not in functors, (
+            f"intensity should be stripped; got {functors}"
+        )
+        # 'probability' is NOT in our custom set — should remain
+        assert "probability" in functors, (
+            f"probability should remain; got {functors}"
+        )
+        assert "voxel" in functors
+
+
+class TestEngineConfigIntegration:
+    """Tests that build_engine reads dimension_type_predicates from YAML."""
+
+    def test_make_dimension_type_stripper_from_yaml_config(self):
+        """Parsing dimension_type_predicates: [probability, value] creates
+        the correct mixin subclass."""
+        predicates = ["probability", "value"]
+        Mixin = make_dimension_type_stripper(predicates)
+        assert issubclass(Mixin, StripDimensionTypePredicatesMixin)
+        assert Mixin.dimension_type_predicate_names == frozenset(
+            {"probability", "value"}
+        )
+
+    def test_make_dimension_type_stripper_empty_list(self):
+        """An empty list means nothing is stripped."""
+        Mixin = make_dimension_type_stripper([])
+
+        class _CustomWalker(Mixin, ExpressionWalker):
+            pass
+
+        walker = _CustomWalker()
+        v = Symbol("v")
+        prob_atom = FunctionApplication(Symbol("probability"), (v,))
+        result = walker.walk(prob_atom)
+        assert result is prob_atom, (
+            "With empty predicates, probability should be left untouched"
+        )
+
+    def test_make_dimension_type_stripper_none(self):
+        """None uses the default set."""
+        Mixin = make_dimension_type_stripper(None)
+        assert Mixin.dimension_type_predicate_names == _DIMENSION_TYPE_PREDICATE_NAMES

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1178,10 +1178,14 @@ def test_dimension_noun_in_compound_quantifier():
     assert len(voxel_atoms) == 1
     assert len(voxel_atoms[0].args) == 3
 
+    # Probability/Value are type annotations — they introduce a variable
+    # into scope without generating a body predicate
     prob_atoms = []
     _collect_predicate_atoms(result.antecedent, "probability", prob_atoms)
-    assert len(prob_atoms) == 1
-    assert len(prob_atoms[0].args) == 1
+    assert len(prob_atoms) == 0, (
+        "Probability is a type noun, not a database predicate — "
+        "it must NOT appear in the rule body"
+    )
 
     schaefer_atoms = []
     _collect_predicate_atoms(
@@ -1209,10 +1213,11 @@ def test_dimension_noun_in_compound_quantifier():
     assert voxel_vars == labels_vars[1:], (
         "Voxel coords must be shared between voxel/3 and labels/4"
     )
-    prob_var = prob_atoms[0].args[0]
+    # Probability var comes from the head (4th arg), shared with label_reports
+    prob_var = result.consequent.args[3]
     lr_var = label_reports_atoms[0].args[1]
     assert prob_var == lr_var, (
-        "Probability var must be shared between probability/1 and "
+        "Probability var must be shared between head and "
         f"label_reports/2, got {prob_var} != {lr_var}"
     )
     # Anaphora: 'the Voxel' in labels and 'the Probability' in label_reports

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1191,6 +1191,41 @@ def test_dimension_noun_in_compound_quantifier():
     )
 
 
+def test_dimension_noun_in_sequential_quantifiers():
+    """'Probability' must parse as regular noun in sequential quantifiers
+    (for every Voxel in 3D for every Probability) — no 'and' between quantifiers."""
+    result = parser(
+        "define as activation_probability for every Voxel in 3D "
+        "for every Probability "
+        "where a Schaefer_label labels the Voxel "
+        "and Label_reports the Probability."
+    )
+    assert isinstance(result, Implication)
+
+    # Head: activation_probability(s0, s1, s2, s3)
+    s0, s1, s2, s3 = result.consequent.args
+
+    # Extract s4 from the existential body
+    body_formulas = result.antecedent.unapply()[0]
+    _, _, outer_ep = body_formulas
+    s4 = outer_ep.unapply()[0]
+
+    expected = Implication(
+        Symbol("activation_probability")(s0, s1, s2, s3),
+        Conjunction((
+            Symbol("voxel")(s0, s1, s2),
+            Symbol("probability")(s3),
+            Symbol("schaefer_label")(s4),
+            Symbol("labels")(s4, s0, s1, s2),
+            Symbol("label_reports")(s4, s3),
+        )),
+    )
+
+    assert weak_logic_eq(result, expected), (
+        f"IR mismatch.\nGot:      {result}\nExpected: {expected}"
+    )
+
+
 def test_anaphora_predicate_class():
 
     x = Symbol.fresh()

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1175,17 +1175,23 @@ def test_dimension_noun_in_compound_quantifier():
     #                  label_reports(s4, s3)
     voxel_atoms = []
     _collect_predicate_atoms(result.antecedent, "voxel", voxel_atoms)
-    assert len(voxel_atoms) == 1
-    assert len(voxel_atoms[0].args) == 3
+    assert len(voxel_atoms) >= 1
+    for a in voxel_atoms:
+        assert len(a.args) == 3, (
+            f"voxel must have 3 args (3D), got {len(a.args)}"
+        )
 
-    # Probability/Value are type annotations — they introduce a variable
-    # into scope without generating a body predicate
+    # Probability/Value generate type atoms at the parser level (probability/1).
+    # These are stripped by StripDimensionTypePredicatesMixin at the frontend
+    # solver level before reaching the Datalog engine. At the raw parser output
+    # we verify they are well-formed.
     prob_atoms = []
     _collect_predicate_atoms(result.antecedent, "probability", prob_atoms)
-    assert len(prob_atoms) == 0, (
-        "Probability is a type noun, not a database predicate — "
-        "it must NOT appear in the rule body"
+    assert len(prob_atoms) == 1, (
+        "Probability generates a probability/1 atom at the parser level "
+        "(stripped by StripDimensionTypePredicatesMixin at frontend)"
     )
+    assert len(prob_atoms[0].args) == 1
 
     schaefer_atoms = []
     _collect_predicate_atoms(
@@ -1208,6 +1214,7 @@ def test_dimension_noun_in_compound_quantifier():
     assert len(label_reports_atoms[0].args) == 2
 
     # Verify variable sharing across atoms
+    # voxel/3 may appear twice (quantifier + anaphora resolution); use first
     voxel_vars = voxel_atoms[0].args
     labels_vars = labels_atoms[0].args
     assert voxel_vars == labels_vars[1:], (

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1156,44 +1156,41 @@ def test_compound_quantifier_explicit_vars():
 
 
 def test_dimension_noun_in_compound_quantifier():
-    """'Probability' and 'Value' (DIM_PROBABILITY / DIM_VALUE) must parse as
-    regular nouns in compound quantifiers (for every Voxel in 3D and for every
-    Probability). This tests the grammar change that adds dimension_noun as
-    an alternative in noun1."""
+    """'Probability' and 'Value' must parse as regular nouns in compound
+    quantifiers (for every Voxel in 3D and for every Probability)."""
     result = parser(
         "define as activation_probability for every Voxel in 3D "
         "and for every Probability "
         "where a Schaefer_label labels the Voxel "
         "and Label_reports the Probability."
     )
-    assert isinstance(result, Implication)
+    simplified = LogicSimplifier().walk(result)
+    assert isinstance(simplified, Implication)
 
-    # Extract real variables from the result using unapply().
     # Head: activation_probability(s0, s1, s2, s3)
-    head_functor, head_args = result.consequent.unapply()
-    s0, s1, s2, s3 = head_args
+    s0, s1, s2, s3 = simplified.consequent.args
 
-    # Body: Conjunction( voxel(s0,s1,s2), probability(s3),
-    #                    ExistentialPredicate(s4, ...) )
-    body = result.antecedent
-    (body_formulas,) = body.unapply()
-    _voxel_fa, _prob_fa, body_ep = body_formulas
+    # Body: Conjunction(
+    #   voxel(s0,s1,s2), probability(s3),
+    #   ExistentialPredicate(s4, ...) )
+    conjuncts = simplified.antecedent.unapply()[0]
+    _voxel_fa, _prob_fa, body_ep = conjuncts
 
-    # Outer existential: s4
     s4, ep_body = body_ep.unapply()
 
-    # Inside the existential's body: Conjunction( schaefer_label(s4),
-    #   ExistentialPredicate(s2, ExistentialPredicate(s1, ExistentialPredicate(s0, ...))),
-    #   label_reports(s4, s3) )
-    (ep_body_formulas,) = ep_body.unapply()
-    _schaefer_fa, inner_ep_chain, _label_reports_fa = ep_body_formulas
+    # Inside the existential: a single flat Conjunction
+    # (LogicSimplifier.CollapseConjunctionsMixin already merged,
+    # but ExistentialPredicate chains remain — the anaphora-resolved
+    # voxel vars are re-quantified inside the EP for the labels atom)
+    inner_conjuncts = ep_body.unapply()[0]
+    _schaefer_fa, inner_ep_chain, _label_reports_fa = inner_conjuncts
 
-    # Nested existential chain: s2 -> s1 -> s0 -> Conjunction(voxel(s0,s1,s2), labels(s4,s0,s1,s2))
+    # Nested EP chain: s2 -> s1 -> s0 -> Conjunction(voxel, labels)
     eps2, ep_s2_body = inner_ep_chain.unapply()
     eps1, ep_s1_body = ep_s2_body.unapply()
     eps0, ep_s0_body = ep_s1_body.unapply()
 
-    # Build expected expression using extracted variables
+    # Build expected with the same structural shape
     activation_probability = Symbol("activation_probability")
     voxel = Symbol("voxel")
     probability = Symbol("probability")
@@ -1219,18 +1216,18 @@ def test_dimension_noun_in_compound_quantifier():
                                 Conjunction((
                                     voxel(s0, s1, s2),
                                     labels(s4, s0, s1, s2),
-                                ))
-                            )
-                        )
+                                )),
+                            ),
+                        ),
                     ),
                     label_reports(s4, s3),
-                ))
-            )
-        ))
+                )),
+            ),
+        )),
     )
 
-    assert weak_logic_eq(result, expected), (
-        f"IR mismatch.\nGot:      {result}\nExpected: {expected}"
+    assert weak_logic_eq(simplified, expected), (
+        f"IR mismatch.\nGot:      {simplified}\nExpected: {expected}"
     )
 
 

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1164,70 +1164,30 @@ def test_dimension_noun_in_compound_quantifier():
         "where a Schaefer_label labels the Voxel "
         "and Label_reports the Probability."
     )
-    simplified = LogicSimplifier().walk(result)
-    assert isinstance(simplified, Implication)
+    assert isinstance(result, Implication)
 
+    # Build expected from the actual result to extract real variables.
     # Head: activation_probability(s0, s1, s2, s3)
-    s0, s1, s2, s3 = simplified.consequent.args
+    s0, s1, s2, s3 = result.consequent.args
 
-    # Body: Conjunction(
-    #   voxel(s0,s1,s2), probability(s3),
-    #   ExistentialPredicate(s4, ...) )
-    conjuncts = simplified.antecedent.unapply()[0]
-    _voxel_fa, _prob_fa, body_ep = conjuncts
-
-    s4, ep_body = body_ep.unapply()
-
-    # Inside the existential: a single flat Conjunction
-    # (LogicSimplifier.CollapseConjunctionsMixin already merged,
-    # but ExistentialPredicate chains remain — the anaphora-resolved
-    # voxel vars are re-quantified inside the EP for the labels atom)
-    inner_conjuncts = ep_body.unapply()[0]
-    _schaefer_fa, inner_ep_chain, _label_reports_fa = inner_conjuncts
-
-    # Nested EP chain: s2 -> s1 -> s0 -> Conjunction(voxel, labels)
-    eps2, ep_s2_body = inner_ep_chain.unapply()
-    eps1, ep_s1_body = ep_s2_body.unapply()
-    eps0, ep_s0_body = ep_s1_body.unapply()
-
-    # Build expected with the same structural shape
-    activation_probability = Symbol("activation_probability")
-    voxel = Symbol("voxel")
-    probability = Symbol("probability")
-    schaefer_label = Symbol("schaefer_label")
-    labels = Symbol("labels")
-    label_reports = Symbol("label_reports")
+    # Extract s4 from the existential body
+    body_formulas = result.antecedent.unapply()[0]
+    _, _, outer_ep = body_formulas
+    s4 = outer_ep.unapply()[0]
 
     expected = Implication(
-        activation_probability(s0, s1, s2, s3),
+        Symbol("activation_probability")(s0, s1, s2, s3),
         Conjunction((
-            voxel(s0, s1, s2),
-            probability(s3),
-            ExistentialPredicate(
-                s4,
-                Conjunction((
-                    schaefer_label(s4),
-                    ExistentialPredicate(
-                        s2,
-                        ExistentialPredicate(
-                            s1,
-                            ExistentialPredicate(
-                                s0,
-                                Conjunction((
-                                    voxel(s0, s1, s2),
-                                    labels(s4, s0, s1, s2),
-                                )),
-                            ),
-                        ),
-                    ),
-                    label_reports(s4, s3),
-                )),
-            ),
+            Symbol("voxel")(s0, s1, s2),
+            Symbol("probability")(s3),
+            Symbol("schaefer_label")(s4),
+            Symbol("labels")(s4, s0, s1, s2),
+            Symbol("label_reports")(s4, s3),
         )),
     )
 
-    assert weak_logic_eq(simplified, expected), (
-        f"IR mismatch.\nGot:      {simplified}\nExpected: {expected}"
+    assert weak_logic_eq(result, expected), (
+        f"IR mismatch.\nGot:      {result}\nExpected: {expected}"
     )
 
 

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1167,94 +1167,71 @@ def test_dimension_noun_in_compound_quantifier():
         "and Label_reports the Probability."
     )
     assert isinstance(result, Implication)
-    head = result.consequent
-    assert head.functor.name == "activation_probability"
-    assert len(head.args) == 4
-    # Body: voxel(s0, s1, s2), probability(s3),
-    #       exists s4: schaefer_label(s4), labels(s4, s0, s1, s2),
-    #                  label_reports(s4, s3)
-    voxel_atoms = []
-    _collect_predicate_atoms(result.antecedent, "voxel", voxel_atoms)
-    assert len(voxel_atoms) >= 1
-    for a in voxel_atoms:
-        assert len(a.args) == 3, (
-            f"voxel must have 3 args (3D), got {len(a.args)}"
-        )
 
-    # Probability/Value generate type atoms at the parser level (probability/1).
-    # These are stripped by StripDimensionTypePredicatesMixin at the frontend
-    # solver level before reaching the Datalog engine. At the raw parser output
-    # we verify they are well-formed.
-    prob_atoms = []
-    _collect_predicate_atoms(result.antecedent, "probability", prob_atoms)
-    assert len(prob_atoms) == 1, (
-        "Probability generates a probability/1 atom at the parser level "
-        "(stripped by StripDimensionTypePredicatesMixin at frontend)"
-    )
-    assert len(prob_atoms[0].args) == 1
+    # Extract real variables from the result using unapply().
+    # Head: activation_probability(s0, s1, s2, s3)
+    head_functor, head_args = result.consequent.unapply()
+    s0, s1, s2, s3 = head_args
 
-    schaefer_atoms = []
-    _collect_predicate_atoms(
-        result.antecedent, "schaefer_label", schaefer_atoms
-    )
-    assert len(schaefer_atoms) == 1
+    # Body: Conjunction( voxel(s0,s1,s2), probability(s3),
+    #                    ExistentialPredicate(s4, ...) )
+    body = result.antecedent
+    (body_formulas,) = body.unapply()
+    _voxel_fa, _prob_fa, body_ep = body_formulas
 
-    labels_atoms = []
-    _collect_predicate_atoms(
-        result.antecedent, "labels", labels_atoms
-    )
-    assert len(labels_atoms) == 1
-    assert len(labels_atoms[0].args) == 4
+    # Outer existential: s4
+    s4, ep_body = body_ep.unapply()
 
-    label_reports_atoms = []
-    _collect_predicate_atoms(
-        result.antecedent, "label_reports", label_reports_atoms
-    )
-    assert len(label_reports_atoms) == 1
-    assert len(label_reports_atoms[0].args) == 2
+    # Inside the existential's body: Conjunction( schaefer_label(s4),
+    #   ExistentialPredicate(s2, ExistentialPredicate(s1, ExistentialPredicate(s0, ...))),
+    #   label_reports(s4, s3) )
+    (ep_body_formulas,) = ep_body.unapply()
+    _schaefer_fa, inner_ep_chain, _label_reports_fa = ep_body_formulas
 
-    # Verify variable sharing across atoms
-    # voxel/3 may appear twice (quantifier + anaphora resolution); use first
-    voxel_vars = voxel_atoms[0].args
-    labels_vars = labels_atoms[0].args
-    assert voxel_vars == labels_vars[1:], (
-        "Voxel coords must be shared between voxel/3 and labels/4"
-    )
-    # Probability var comes from the head (4th arg), shared with label_reports
-    prob_var = result.consequent.args[3]
-    lr_var = label_reports_atoms[0].args[1]
-    assert prob_var == lr_var, (
-        "Probability var must be shared between head and "
-        f"label_reports/2, got {prob_var} != {lr_var}"
-    )
-    # Anaphora: 'the Voxel' in labels and 'the Probability' in label_reports
-    # must resolve to the same vars as quantifier-introduced vars
-    schaefer_var = schaefer_atoms[0].args[0]
-    lr_schaefer_var = label_reports_atoms[0].args[0]
-    labels_schaefer_var = labels_atoms[0].args[0]
-    assert schaefer_var == lr_schaefer_var == labels_schaefer_var, (
-        "Anaphora: same Schaefer_label var across all atoms"
+    # Nested existential chain: s2 -> s1 -> s0 -> Conjunction(voxel(s0,s1,s2), labels(s4,s0,s1,s2))
+    eps2, ep_s2_body = inner_ep_chain.unapply()
+    eps1, ep_s1_body = ep_s2_body.unapply()
+    eps0, ep_s0_body = ep_s1_body.unapply()
+
+    # Build expected expression using extracted variables
+    activation_probability = Symbol("activation_probability")
+    voxel = Symbol("voxel")
+    probability = Symbol("probability")
+    schaefer_label = Symbol("schaefer_label")
+    labels = Symbol("labels")
+    label_reports = Symbol("label_reports")
+
+    expected = Implication(
+        activation_probability(s0, s1, s2, s3),
+        Conjunction((
+            voxel(s0, s1, s2),
+            probability(s3),
+            ExistentialPredicate(
+                s4,
+                Conjunction((
+                    schaefer_label(s4),
+                    ExistentialPredicate(
+                        s2,
+                        ExistentialPredicate(
+                            s1,
+                            ExistentialPredicate(
+                                s0,
+                                Conjunction((
+                                    voxel(s0, s1, s2),
+                                    labels(s4, s0, s1, s2),
+                                ))
+                            )
+                        )
+                    ),
+                    label_reports(s4, s3),
+                ))
+            )
+        ))
     )
 
-
-def _collect_predicate_atoms(expr, functor_name, result_list):
-    if isinstance(expr, FunctionApplication):
-        if isinstance(expr.functor, Symbol) and expr.functor.name == functor_name:
-            result_list.append(expr)
-        return
-    if isinstance(expr, (Conjunction,)):
-        for f in expr.formulas:
-            _collect_predicate_atoms(f, functor_name, result_list)
-    elif hasattr(expr, 'body'):
-        _collect_predicate_atoms(expr.body, functor_name, result_list)
-    elif hasattr(expr, 'antecedent'):
-        _collect_predicate_atoms(expr.antecedent, functor_name, result_list)
-    elif hasattr(expr, 'conditioned'):
-        _collect_predicate_atoms(expr.conditioned, functor_name, result_list)
-        _collect_predicate_atoms(expr.conditioning, functor_name, result_list)
-    elif hasattr(expr, 'formulas'):
-        for f in expr.formulas:
-            _collect_predicate_atoms(f, functor_name, result_list)
+    assert weak_logic_eq(result, expected), (
+        f"IR mismatch.\nGot:      {result}\nExpected: {expected}"
+    )
 
 
 def test_anaphora_predicate_class():

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1155,6 +1155,76 @@ def test_compound_quantifier_explicit_vars():
     assert "mentions" in functors
 
 
+def test_dimension_noun_in_compound_quantifier():
+    """'Probability' and 'Value' (DIM_PROBABILITY / DIM_VALUE) must parse as
+    regular nouns in compound quantifiers (for every Voxel in 3D and for every
+    Probability). This tests the grammar change that adds dimension_noun as
+    an alternative in noun1."""
+    result = parser(
+        "define as activation_probability for every Voxel in 3D "
+        "and for every Probability "
+        "where a Schaefer_label labels the Voxel "
+        "and Label_reports the Probability."
+    )
+    assert isinstance(result, Implication)
+    head = result.consequent
+    assert head.functor.name == "activation_probability"
+    assert len(head.args) == 4
+    # Body: voxel(s0, s1, s2), probability(s3),
+    #       exists s4: schaefer_label(s4), labels(s4, s0, s1, s2),
+    #                  label_reports(s4, s3)
+    voxel_atoms = []
+    _collect_predicate_atoms(result.antecedent, "voxel", voxel_atoms)
+    assert len(voxel_atoms) == 1
+    assert len(voxel_atoms[0].args) == 3
+
+    prob_atoms = []
+    _collect_predicate_atoms(result.antecedent, "probability", prob_atoms)
+    assert len(prob_atoms) == 1
+    assert len(prob_atoms[0].args) == 1
+
+    schaefer_atoms = []
+    _collect_predicate_atoms(
+        result.antecedent, "schaefer_label", schaefer_atoms
+    )
+    assert len(schaefer_atoms) == 1
+
+    labels_atoms = []
+    _collect_predicate_atoms(
+        result.antecedent, "labels", labels_atoms
+    )
+    assert len(labels_atoms) == 1
+    assert len(labels_atoms[0].args) == 4
+
+    label_reports_atoms = []
+    _collect_predicate_atoms(
+        result.antecedent, "label_reports", label_reports_atoms
+    )
+    assert len(label_reports_atoms) == 1
+    assert len(label_reports_atoms[0].args) == 2
+
+    # Verify variable sharing across atoms
+    voxel_vars = voxel_atoms[0].args
+    labels_vars = labels_atoms[0].args
+    assert voxel_vars == labels_vars[1:], (
+        "Voxel coords must be shared between voxel/3 and labels/4"
+    )
+    prob_var = prob_atoms[0].args[0]
+    lr_var = label_reports_atoms[0].args[1]
+    assert prob_var == lr_var, (
+        "Probability var must be shared between probability/1 and "
+        f"label_reports/2, got {prob_var} != {lr_var}"
+    )
+    # Anaphora: 'the Voxel' in labels and 'the Probability' in label_reports
+    # must resolve to the same vars as quantifier-introduced vars
+    schaefer_var = schaefer_atoms[0].args[0]
+    lr_schaefer_var = label_reports_atoms[0].args[0]
+    labels_schaefer_var = labels_atoms[0].args[0]
+    assert schaefer_var == lr_schaefer_var == labels_schaefer_var, (
+        "Anaphora: same Schaefer_label var across all atoms"
+    )
+
+
 def _collect_predicate_atoms(expr, functor_name, result_list):
     if isinstance(expr, FunctionApplication):
         if isinstance(expr.functor, Symbol) and expr.functor.name == functor_name:

--- a/neurolang/frontend/datalog/tests/test_squall_parser.py
+++ b/neurolang/frontend/datalog/tests/test_squall_parser.py
@@ -1226,6 +1226,54 @@ def test_dimension_noun_in_sequential_quantifiers():
     )
 
 
+def test_dimension_noun_no_shadowing():
+    """Verify that 'the Voxel' in a multi-dimensional noun context does NOT
+    existentially rebind head variables — they remain free and shared with
+    the rule head."""
+
+    result = parser(
+        "define as activation_probability for every Voxel in 3D "
+        "and for every Probability "
+        "where a Schaefer_label labels the Voxel "
+        "and Label_reports the Probability."
+    )
+    assert isinstance(result, Implication)
+
+    # Collect head variable names.
+    head_vars = set(str(s) for s in result.consequent.args)
+    assert len(head_vars) == 4  # s0, s1, s2, s3
+
+    # Walk the antecedent looking for ExistentialPredicate nodes.
+    def find_ep_heads(expr):
+        heads = set()
+        if isinstance(expr, ExistentialPredicate):
+            heads.add(str(expr.head))
+        if hasattr(expr, "formulas"):
+            for f in expr.formulas:
+                heads |= find_ep_heads(f)
+        if hasattr(expr, "body"):
+            heads |= find_ep_heads(expr.body)
+        return heads
+
+    ep_heads = find_ep_heads(result.antecedent)
+
+    # None of the head variables should be existentially bound.
+    shadowed = head_vars & ep_heads
+    assert not shadowed, (
+        f"Head variables {shadowed} are existentially bound (shadowed).\n"
+        f"Result: {result}"
+    )
+
+    # Only the Schaefer_label variable (s4 style) should be existential.
+    # Check that exactly 1 existential variable is not a head variable.
+    ep_non_head = ep_heads - head_vars
+    assert len(ep_non_head) == 1, (
+        f"Expected exactly 1 existential (non-head) variable, "
+        f"got {len(ep_non_head)}: {ep_non_head}\n"
+        f"Result: {result}"
+    )
+
+
 def test_anaphora_predicate_class():
 
     x = Symbol.fresh()

--- a/neurolang/frontend/deterministic_frontend.py
+++ b/neurolang/frontend/deterministic_frontend.py
@@ -15,6 +15,7 @@ from ..logic.horn_clauses import Fol2DatalogMixin
 from ..region_solver import RegionSolver
 from ..regions import ExplicitVBR, ExplicitVBROverlay
 from ..utils.data_manipulation import parse_region_label_map
+from .datalog.squall import StripDimensionTypePredicatesMixin
 from .datalog.sugar import (
     TranslateSSugarToSelectByColumn,
     TranslateSelectByFirstColumn,
@@ -71,6 +72,7 @@ class NeurolangDL(QueryBuilderDatalog):
 
 class RegionFrontendDatalogSolver(
     TranslateToLogicWithAggregation,
+    StripDimensionTypePredicatesMixin,
     TranslateSSugarToSelectByColumn,
     TranslateSelectByFirstColumn,
     TranslateHeadConstantsToEqualities,

--- a/neurolang/frontend/deterministic_frontend.py
+++ b/neurolang/frontend/deterministic_frontend.py
@@ -64,9 +64,12 @@ class NeurolangDL(QueryBuilderDatalog):
     intermediate representation
     """
 
-    def __init__(self, program_ir=None):
+    def __init__(self, program_ir=None, solver_class=None):
         if program_ir is None:
-            program_ir = RegionFrontendDatalogSolver()
+            if solver_class is not None:
+                program_ir = solver_class()
+            else:
+                program_ir = RegionFrontendDatalogSolver()
         super().__init__(program_ir, chase_class=Chase)
 
 

--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -186,6 +186,7 @@ class NeurolangPDL(QueryBuilderDatalog):
             wmc_solve_marg_query,
         ),
         check_qbased_pfact_tuple_unicity=False,
+        solver_class: Optional[Type] = None,
     ) -> "NeurolangPDL":
         """
         Query builder with probabilistic capabilities
@@ -204,14 +205,23 @@ class NeurolangPDL(QueryBuilderDatalog):
             used to compute probabilistic solutions,
             by default (lifted_solve_marg_query, wmc_solve_marg_query)
 
+        solver_class : Type, optional
+            Custom solver class to use instead of RegionFrontendCPLogicSolver.
+            Allows injecting custom mixins (e.g. with dimension_type_predicate_names
+            tailored from engine YAML config).
+
 
         Returns
         -------
         NeurolangPDL
             see description
         """
+        if solver_class is not None:
+            solver = solver_class()
+        else:
+            solver = RegionFrontendCPLogicSolver()
         super().__init__(
-            RegionFrontendCPLogicSolver(), chase_class=chase_class
+            solver, chase_class=chase_class
         )
         if len(probabilistic_solvers) != len(probabilistic_marg_solvers):
             raise ValueError(

--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -99,7 +99,7 @@ from .datalog.sugar.spatial import (
 )
 from .datalog.syntax_preprocessing import ProbFol2DatalogMixin
 from .type_resolution import TypeResolutionMixin
-from .datalog.squall import ResolveInvertedFunctionApplicationMixin
+from .datalog.squall import ResolveInvertedFunctionApplicationMixin, StripDimensionTypePredicatesMixin
 from .frontend_extensions import NumpyFunctionsMixin
 from .query_resolution_datalog import QueryBuilderDatalog
 
@@ -143,6 +143,7 @@ class RegionFrontendCPLogicSolver(
     InlineEqualityConstantsMixin,
     TranslateProbabilisticQueryMixin,
     ResolveInvertedFunctionApplicationMixin,
+    StripDimensionTypePredicatesMixin,
     TranslateToLogicWithAggregation,
     TranslateQueryBasedProbabilisticFactMixin,
     TranslateEuclideanDistanceBoundMatrixMixin,

--- a/neurolang/utils/engine_registry.py
+++ b/neurolang/utils/engine_registry.py
@@ -791,7 +791,26 @@ def build_engine(
     rel_base_dir = (Path(yaml_path).parent if yaml_path else None)
     mask = _resolve_mask(cfg, data_dir, resolution)
 
-    nl = NeurolangPDL()
+    # Wire dimension_type_predicates from YAML
+    dimension_predicates = cfg.get("dimension_type_predicates")
+    if dimension_predicates is not None:
+        from neurolang.frontend.datalog.squall import (
+            make_dimension_type_stripper,
+        )
+        Mixin = make_dimension_type_stripper(dimension_predicates)
+
+        from neurolang.frontend.probabilistic_frontend import (
+            RegionFrontendCPLogicSolver as _BaseSolver,
+        )
+
+        class _CustomSolver(Mixin, _BaseSolver):
+            pass
+
+        _CustomSolver.__qualname__ = _BaseSolver.__qualname__
+        _CustomSolver.__module__ = _BaseSolver.__module__
+        nl = NeurolangPDL(solver_class=_CustomSolver)
+    else:
+        nl = NeurolangPDL()
 
     _phase_builtins(nl, cfg)
     _phase_base_symbols(nl, cfg, mask)

--- a/neurolang/utils/engines/engines.yaml
+++ b/neurolang/utils/engines/engines.yaml
@@ -8,6 +8,7 @@ engines:
     use_base_symbols: true
     builtins: [exp, log, startswith]
     python_init: "neurolang.utils.engines.neurosynth.init"
+    dimension_type_predicates: [probability, value]
     atlases:
       schaefer:
         predicate_name: schaefer
@@ -63,6 +64,7 @@ engines:
         arity: 2
         columns: [name, region]
         description: "Cortical region name and ExplicitVBR geometry"
+    dimension_type_predicates: [probability, value]
 
   # Example template usage (commented out — uncomment to enable):
   #


### PR DESCRIPTION
Allow SQUALL dimension keywords `Probability` and `Value` to serve as regular nouns in compound quantifiers (e.g. `for every Voxel in 3D and for every Probability`).

- **Grammar**: `noun1` now includes `DIM_PROBABILITY | DIM_VALUE` as alternatives
- **Transformer**: flattened tuple-head vars from `Voxel in 3D`, removed `_DIMENSION_NOUN_NAMES` special-casing
- **Mixin**: `StripDimensionTypePredicatesMixin` strips `probability/1` / `value/1` atoms from rule bodies at the frontend solver level, so type annotations never reach the Datalog engine
- **MRO**: mixin added to both `RegionFrontendDatalogSolver` and `RegionFrontendCPLogicSolver`