### PR TITLE
fix: benchmark workflow -- `asv run --new` → `asv run NEW`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run benchmarks
         run: |
           asv machine --yes
-          asv run --new
+          asv run NEW
         timeout-minutes: 60
 
       - name: Publish HTML dashboard


### PR DESCRIPTION
The `--new` flag does not exist in ASV 0.6.5. The correct syntax uses `NEW` as a positional argument to benchmark all commits since the last benchmarked commit on this machine.

This was causing the benchmark CI to fail with:
```
asv: error: unrecognized arguments: --new
```