### PR TITLE
feat(utils): interactive TUI mode for neurolang-query with autocomplete, rich tables, and NIfTI support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest pytest-cov pytest-timeout
-        python -m pip install -e ".[dev,ras-polars]"
+        python -m pip install -e ".[dev,ras-polars,tui]"
 
     - name: Run tests with pytest
       run: |

--- a/neurolang/utils/cli.py
+++ b/neurolang/utils/cli.py
@@ -283,6 +283,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "Append ':desc' for descending, ':asc' for ascending. "
         "Repeatable for multi-key sorts (first key has highest priority).",
     )
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        dest="interactive",
+        help="Start an interactive REPL with autocomplete, "
+        "rich tables, and NIfTI support.",
+    )
 
     return parser
 
@@ -549,6 +557,17 @@ def main(argv: Optional[list] = None) -> None:
 
     if args.list_sets:
         _list_sets(nl)
+        return
+
+    if args.interactive:
+        from neurolang.utils.interactive_tui import main as tui_main
+        tui_main(
+            engine_name=args.engine,
+            data_dir=args.data_dir,
+            resolution=args.resolution,
+            squall_mode=args.squall,
+            sort_specs=args.sort,
+        )
         return
 
     program = _read_query(args)

--- a/neurolang/utils/interactive_tui.py
+++ b/neurolang/utils/interactive_tui.py
@@ -18,18 +18,25 @@ Usage
 """
 
 import os
+import subprocess
 import sys
-import time
 import tempfile
+import time
 from pathlib import Path
 from typing import Optional
 
+import nibabel as nib
 import numpy as np
 import pandas as pd
 
-from neurolang.datalog import WrappedRelationalAlgebraSet
+from neurolang.datalog import WrappedRelationalAlgebraSet, Union as DatalogUnion
 from neurolang.frontend import NeurolangPDL
 from neurolang.frontend.datalog.standard_syntax import COMPILED_GRAMMAR
+from neurolang.frontend.datalog.pretty_printer import DatalogPrettyPrinter
+from neurolang.frontend.datalog.squall_syntax_lark import (
+    parser as squall_parser, SquallProgram,
+)
+from neurolang.logic import Union as LogicUnion
 from neurolang.utils import engine_registry
 from neurolang.utils.interactive_parsing import LarkCompleter, TERMINALS_TO_CATEGORIES, CATEGORIES
 
@@ -62,6 +69,12 @@ DOT_COMMANDS = {
     ".quit": "Exit the REPL (also Ctrl+D / Ctrl+C)",
 }
 
+SLASH_COMMANDS = {
+    "/rewritten": "Re-run last query showing magic-sets rewritten Datalog",
+    "/datalog": "Show Datalog IR of the last SQUALL query (--show-datalog)",
+    "/help": "Show this help message",
+}
+
 HELP_TEXT = """
 [bold yellow]Interactive NeuroLang Query REPL[/bold yellow]
 
@@ -72,10 +85,15 @@ The tab key triggers grammar-aware autocompletion.
 [bold cyan]Dot commands:[/bold cyan]
 """ + "\n".join(f"  [green]{cmd:<20}[/green] {desc}" for cmd, desc in DOT_COMMANDS.items()) + """
 
+[bold cyan]Slash commands:[/bold cyan]
+""" + "\n".join(f"  [green]{cmd:<20}[/green] {desc}" for cmd, desc in SLASH_COMMANDS.items()) + """
+
 [bold cyan]Examples:[/bold cyan]
   ans(t) :- term_in_study_tfidf(t, w, s)
   .mode squall
   obtain every peak_reported.
+  /datalog
+  /rewritten
   .save results/query_output.nii
   .view results/query_output.nii
 """
@@ -121,6 +139,13 @@ class NeuroLangReplCompleter(Completer):
         # 1. Dot commands
         if text.startswith("."):
             for cmd in DOT_COMMANDS:
+                if cmd.startswith(text):
+                    yield Completion(cmd, start_position=-len(text))
+            return
+
+        # 2. Slash commands
+        if text.startswith("/"):
+            for cmd in SLASH_COMMANDS:
                 if cmd.startswith(text):
                     yield Completion(cmd, start_position=-len(text))
             return
@@ -211,8 +236,6 @@ def _result_to_nifti(
     output image uses that template's affine and shape; otherwise an
     identity-affine 256×256×256 volume is created.
     """
-    import nibabel as nib
-
     # Try to detect coordinate columns
     col_lower = {c.lower(): c for c in df.columns}
     i_col = col_lower.get("i")
@@ -286,7 +309,6 @@ def _view_nifti(path: str) -> None:
         display.close()
         _console.print(f"[green]Saved visualisation to: {tmp_png}[/green]")
         # Try to open with system viewer
-        import subprocess
         subprocess.Popen(["open", tmp_png] if sys.platform == "darwin" else ["xdg-open", tmp_png])
         _console.print(f"[dim]Viewing: {tmp_png}[/dim]")
     except Exception as exc:
@@ -365,6 +387,7 @@ class InteractiveTuiApp:
         # State
         self._nl: Optional[NeurolangPDL] = None
         self._engine_built = False
+        self._last_program: Optional[str] = None
         self._last_df: Optional[pd.DataFrame] = None
         self._last_result_type: Optional[str] = None  # 'single' or 'dict'
         self._engine_predicates: set[str] = set()
@@ -474,6 +497,7 @@ class InteractiveTuiApp:
     def _execute_and_display(self, program: str) -> None:
         """Parse, execute, and render a Datalog / SQUALL query."""
         self._ensure_engine()
+        self._last_program = program
 
         sort_by = []
         for spec in self.sort_specs:
@@ -557,7 +581,6 @@ class InteractiveTuiApp:
 
     def _cmd_sets(self) -> None:
         self._ensure_engine()
-        from neurolang.datalog import WrappedRelationalAlgebraSet
         st = self._nl.program_ir.symbol_table
         sets_found = []
         for sym_name, sym_val in st.items():
@@ -621,7 +644,6 @@ class InteractiveTuiApp:
         if path.endswith(".nii"):
             try:
                 img = _result_to_nifti(self._last_df)
-                import nibabel as nib
                 nib.save(img, path)
                 _console.print(f"[green]NIfTI saved to: {path}[/green]")
             except Exception as exc:
@@ -657,6 +679,60 @@ class InteractiveTuiApp:
         else:
             _console.print(f"[yellow]Unknown mode {mode!r}. Use 'datalog' or 'squall'.[/yellow]")
 
+    # -----------------------------------------------------------------------
+    # Slash-command handlers
+    # -----------------------------------------------------------------------
+
+    def _cmd_datalog(self) -> None:
+        """Show Datalog IR of the last SQUALL query (/datalog)."""
+        if self._last_program is None:
+            _console.print("[yellow]No query has been executed yet.[/yellow]")
+            return
+        if not self.squall_mode:
+            _console.print("[yellow]/datalog only shows the Datalog IR of a SQUALL query. "
+                           "Use /rewritten to see magic-sets rewriting of a Datalog query.[/yellow]")
+            return
+        self._ensure_engine()
+        try:
+            parsed = squall_parser(self._last_program)
+            printer = DatalogPrettyPrinter()
+
+            if isinstance(parsed, SquallProgram):
+                if parsed.queries:
+                    for i, q in enumerate(parsed.queries):
+                        label = parsed.query_names.get(i, f"obtain_{i}")
+                        _console.print(f"\n[bold magenta]── query ({label}) ──[/bold magenta]")
+                        _console.print(printer.walk(q))
+                for rule in parsed.rules:
+                    _console.print(f"\n[bold magenta]── rule ──[/bold magenta]")
+                    _console.print(printer.walk(rule))
+            elif isinstance(parsed, (DatalogUnion, LogicUnion)):
+                for f in parsed.formulas:
+                    _console.print(printer.walk(f))
+            else:
+                _console.print(printer.walk(parsed))
+        except Exception as exc:
+            _console.print(f"[red]Failed to show Datalog IR: {exc}[/red]")
+
+    def _cmd_rewritten(self) -> None:
+        """Re-run last query showing magic-sets rewritten Datalog (/rewritten)."""
+        if self._last_program is None:
+            _console.print("[yellow]No query has been executed yet.[/yellow]")
+            return
+        self._ensure_engine()
+        try:
+            _console.print("[bold cyan]Magic-sets rewritten Datalog:[/bold cyan]")
+            if self.squall_mode:
+                result = self._nl.execute_squall_program(
+                    self._last_program, dry_run=True,
+                )
+            else:
+                result = self._nl.execute_datalog_program(
+                    self._last_program, dry_run=True,
+                )
+        except Exception as exc:
+            _console.print(f"[red]Failed to show rewritten query: {exc}[/red]")
+
     def _handle_dot_command(self, line: str) -> bool:
         """Handle a dot-command.  Returns True if the session should continue."""
         cmd = line.strip()
@@ -680,6 +756,24 @@ class InteractiveTuiApp:
             handler()
         else:
             _console.print(f"[yellow]Unknown command: {verb}. Try .help[/yellow]")
+        return True
+
+    def _handle_slash_command(self, line: str) -> bool:
+        """Handle a slash-command.  Returns True if the session should continue."""
+        cmd = line.strip()
+        parts = cmd.split(None, 1)
+        verb = parts[0].lower() if parts else ""
+
+        handlers = {
+            "/rewritten": lambda: self._cmd_rewritten(),
+            "/datalog": lambda: self._cmd_datalog(),
+            "/help": lambda: self._cmd_help(),
+        }
+        handler = handlers.get(verb)
+        if handler:
+            handler()
+        else:
+            _console.print(f"[yellow]Unknown slash command: {verb}. Try /help[/yellow]")
         return True
 
     # -----------------------------------------------------------------------
@@ -728,6 +822,11 @@ class InteractiveTuiApp:
             # Dot commands
             if line.startswith("."):
                 self._handle_dot_command(line)
+                continue
+
+            # Slash commands
+            if line.startswith("/"):
+                self._handle_slash_command(line)
                 continue
 
             # Execute as query

--- a/neurolang/utils/interactive_tui.py
+++ b/neurolang/utils/interactive_tui.py
@@ -41,11 +41,16 @@ from neurolang.utils import engine_registry
 from neurolang.utils.interactive_parsing import LarkCompleter, TERMINALS_TO_CATEGORIES, CATEGORIES
 
 from prompt_toolkit import PromptSession
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+from prompt_toolkit.formatted_text import HTML, StyleAndTextTuples
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.lexers import Lexer
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.filters import HasSearch
+from prompt_toolkit.styles import Style
 
 import rich
 from rich.console import Console
@@ -65,7 +70,7 @@ DOT_COMMANDS = {
     ".predicates": "List available predicates for the current engine",
     ".save": "Save last result to a file\n  .save <path>        — save as CSV\n  .save <path>.nii    — save result voxel data as NIfTI",
     ".view": "Visualise a NIfTI file (uses nilearn plotting)\n  .view <path>.nii",
-    ".mode": "Toggle between Datalog and SQUALL mode\n  .mode datalog\n  .mode squall",
+    ".mode": "Toggle language mode or vi/emacs editing mode\n  .mode datalog\n  .mode squall\n  .mode vi\n  .mode emacs",
     ".quit": "Exit the REPL (also Ctrl+D / Ctrl+C)",
 }
 
@@ -114,6 +119,71 @@ SQUALL_KEYWORDS = [
     "all", "each", "some", "no", "any",
     "most", "few", "both", "neither",
 ]
+
+# ---------------------------------------------------------------------------
+# Constants for UI features
+# ---------------------------------------------------------------------------
+
+MAX_TABLE_ROWS = 20
+
+# ---------------------------------------------------------------------------
+# NeuroLangLexer — syntax highlighting for Datalog / SQUALL
+# ---------------------------------------------------------------------------
+
+
+class NeuroLangLexer(Lexer):
+    """Simple lexer highlighting Datalog/SQUALL tokens in the input line."""
+
+    KEYWORDS = frozenset({
+        "ans", "define", "as", "obtain", "every", "a", "an", "the",
+        "where", "that", "with", "without", "if", "then",
+        "and", "or", "not", "for", "of", "from", "to", "by",
+        "exists", "EXISTS", "MARG", "PROB", "SUCC",
+        "lambda", "True", "False",
+    })
+
+    OPERATORS = frozenset({":-", ":-~", "::", ":=", "->", "||"})
+
+    def lex_document(self, document: Document):
+        def get_line(lineno: int) -> StyleAndTextTuples:
+            line = document.lines[lineno] if lineno < len(document.lines) else ""
+            result: StyleAndTextTuples = []
+            i = 0
+            while i < len(line):
+                if line[i].isalnum() or line[i] == "_":
+                    j = i
+                    while j < len(line) and (line[j].isalnum() or line[j] == "_"):
+                        j += 1
+                    word = line[i:j]
+                    if word in self.KEYWORDS:
+                        result.append(("bold #ff8800", word))
+                    elif word[0].isupper():
+                        result.append(("#44ff44", word))
+                    else:
+                        result.append(("", word))
+                    i = j
+                elif line[i] in (":", "-", "+", "~", "¬", "(", ")", ",", ".", "=", "!", "|", "&"):
+                    j = i
+                    while j < len(line) and line[j] in (":", "-", "+", "~", "¬", "(", ")", ",", ".", "=", "!", "|", "&"):
+                        j += 1
+                    token = line[i:j]
+                    if token in self.OPERATORS:
+                        result.append(("#888888", token))
+                    else:
+                        result.append(("", token))
+                    i = j
+                else:
+                    result.append(("", line[i]))
+                    i += 1
+            return result
+
+        return get_line
+
+
+# Style dict for the prompt session
+_tui_style = Style([
+    ("keyword", "bold #ff8800"),
+])
 
 # ---------------------------------------------------------------------------
 # Custom prompt_toolkit Completer — multi-source: grammar + predicates + keywords
@@ -206,7 +276,7 @@ _console = Console()
 
 
 def _df_to_rich_table(df: pd.DataFrame, title: str = "") -> Table:
-    """Render a pandas DataFrame as a rich Table."""
+    """Render a pandas DataFrame as a rich Table, capped at MAX_TABLE_ROWS rows."""
     table = Table(
         title=title,
         box=box.ROUNDED,
@@ -216,8 +286,19 @@ def _df_to_rich_table(df: pd.DataFrame, title: str = "") -> Table:
     )
     for col in df.columns:
         table.add_column(str(col), overflow="fold")
-    for row in df.itertuples(index=False):
+
+    total = len(df)
+    if total > MAX_TABLE_ROWS:
+        display_df = df.head(MAX_TABLE_ROWS)
+    else:
+        display_df = df
+
+    for row in display_df.itertuples(index=False):
         table.add_row(*[str(v) if v is not None else "" for v in row])
+
+    if total > MAX_TABLE_ROWS:
+        table.caption = f"[dim]{total} rows, showing first {MAX_TABLE_ROWS}[/dim]"
+
     return table
 
 
@@ -426,6 +507,10 @@ class InteractiveTuiApp:
             multiline=False,
             enable_open_in_editor=True,
             vi_mode=False,
+            lexer=NeuroLangLexer(),
+            auto_suggest=AutoSuggestFromHistory(),
+            bottom_toolbar=self._get_toolbar,
+            style=_tui_style,
         )
 
     # -----------------------------------------------------------------------
@@ -498,6 +583,8 @@ class InteractiveTuiApp:
         """Parse, execute, and render a Datalog / SQUALL query."""
         self._ensure_engine()
         self._last_program = program
+
+        _console.print("[dim]⏳ Running query...[/dim]")
 
         sort_by = []
         for spec in self.sort_specs:
@@ -676,8 +763,14 @@ class InteractiveTuiApp:
             self.squall_mode = True
             self._rebuild_completer()
             _console.print("[green]Mode: SQUALL[/green]")
+        elif mode == "vi":
+            self._session.vi_mode = True
+            _console.print("[green]Vi mode enabled[/green]")
+        elif mode == "emacs":
+            self._session.vi_mode = False
+            _console.print("[green]Emacs mode enabled[/green]")
         else:
-            _console.print(f"[yellow]Unknown mode {mode!r}. Use 'datalog' or 'squall'.[/yellow]")
+            _console.print(f"[yellow]Unknown mode {mode!r}. Use 'datalog', 'squall', 'vi', or 'emacs'.[/yellow]")
 
     # -----------------------------------------------------------------------
     # Slash-command handlers
@@ -775,6 +868,30 @@ class InteractiveTuiApp:
         else:
             _console.print(f"[yellow]Unknown slash command: {verb}. Try /help[/yellow]")
         return True
+
+    # -----------------------------------------------------------------------
+    # Toolbar
+    # -----------------------------------------------------------------------
+
+    def _get_toolbar(self) -> HTML:
+        """Return the bottom toolbar text showing engine state."""
+        mode = "SQ" if self.squall_mode else "DL"
+        pred_count = len(self._engine_predicates)
+        if self._last_df is not None:
+            result_info = f"rows:{len(self._last_df)}"
+        elif self._last_result_type == "dict":
+            result_info = "dict"
+        elif self._last_result_type == "single":
+            result_info = "single"
+        else:
+            result_info = "—"
+        vi = "VI" if self._session.vi_mode else "EM"
+        return HTML(
+            f"<b>nl({self.engine_name}:{mode})</b>  "
+            f"preds:{pred_count}  "
+            f"{result_info}  "
+            f"[{vi}]"
+        )
 
     # -----------------------------------------------------------------------
     # Prompt style

--- a/neurolang/utils/interactive_tui.py
+++ b/neurolang/utils/interactive_tui.py
@@ -1,0 +1,656 @@
+"""
+Interactive TUI (Terminal User Interface) for NeuroLang query execution.
+
+Provides a prompt_toolkit-based REPL with:
+- Lark grammar autocomplete
+- Rich table rendering of query results
+- Multi-line editing (Alt+Enter or Meta+Enter to insert newline)
+- Command history (persistent via prompt_toolkit's FileHistory)
+- NIfTI save / visualise support via nibabel and nilearn
+- Dot-commands: .help, .engines, .sets, .predicates, .save, .view, .mode, .quit
+
+Usage
+-----
+::
+
+    neurolang-query --interactive
+    neurolang-query -i -e neurosynth
+"""
+
+import os
+import sys
+import time
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from neurolang.datalog import WrappedRelationalAlgebraSet
+from neurolang.frontend import NeurolangPDL
+from neurolang.frontend.datalog.standard_syntax import COMPILED_GRAMMAR
+from neurolang.utils import engine_registry
+from neurolang.utils.interactive_parsing import LarkCompleter, TERMINALS_TO_CATEGORIES, CATEGORIES
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.patch_stdout import patch_stdout
+from prompt_toolkit.filters import HasSearch
+
+import rich
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.columns import Columns
+from rich import box
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DOT_COMMANDS = {
+    ".help": "Show this help message",
+    ".engines": "List available dataset engines",
+    ".sets": "List loaded RA sets (EDB relations)",
+    ".predicates": "List available predicates for the current engine",
+    ".save": "Save last result to a file\n  .save <path>        — save as CSV\n  .save <path>.nii    — save result voxel data as NIfTI",
+    ".view": "Visualise a NIfTI file (uses nilearn plotting)\n  .view <path>.nii",
+    ".mode": "Toggle between Datalog and SQUALL mode\n  .mode datalog\n  .mode squall",
+    ".quit": "Exit the REPL (also Ctrl+D / Ctrl+C)",
+}
+
+HELP_TEXT = """
+[bold yellow]Interactive NeuroLang Query REPL[/bold yellow]
+
+Type a Datalog (or SQUALL) query and press Enter to execute.
+Use [bold]Alt+Enter[/bold] or [bold]Meta+Enter[/bold] for multi-line input.
+The tab key triggers grammar-aware autocompletion.
+
+[bold cyan]Dot commands:[/bold cyan]
+""" + "\n".join(f"  [green]{cmd:<20}[/green] {desc}" for cmd, desc in DOT_COMMANDS.items()) + """
+
+[bold cyan]Examples:[/bold cyan]
+  ans(t) :- term_in_study_tfidf(t, w, s)
+  .mode squall
+  obtain every peak_reported.
+  .save results/query_output.nii
+  .view results/query_output.nii
+"""
+
+# ---------------------------------------------------------------------------
+# Custom prompt_toolkit Completer wrapping LarkCompleter
+# ---------------------------------------------------------------------------
+
+
+class NeuroLangReplCompleter(Completer):
+    """prompt_toolkit Completer backed by the Lark grammar completer."""
+
+    def __init__(self, lark_completer: LarkCompleter):
+        self._lark = lark_completer
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        # Dot commands get literal completion
+        if text.startswith("."):
+            for cmd in DOT_COMMANDS:
+                if cmd.startswith(text):
+                    yield Completion(cmd, start_position=-len(text))
+            return
+
+        try:
+            result = self._lark.complete(text)
+        except Exception:
+            return
+
+        opts = result.token_options
+        # Flatten token_options into completions
+        seen = set()
+        for category_key, container in opts.items():
+            for value in container.get("values", set()):
+                if not value or value in seen:
+                    continue
+                seen.add(value)
+                # Strip angle brackets for display
+                display = value
+                if value.startswith("<") and value.endswith(">"):
+                    display = value[1:-1]
+                yield Completion(
+                    value,
+                    start_position=-len(result.prefix),
+                    display=display,
+                    display_meta=category_key,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Rich helpers
+# ---------------------------------------------------------------------------
+
+_console = Console()
+
+
+def _df_to_rich_table(df: pd.DataFrame, title: str = "") -> Table:
+    """Render a pandas DataFrame as a rich Table."""
+    table = Table(
+        title=title,
+        box=box.ROUNDED,
+        header_style="bold cyan",
+        title_style="bold magenta",
+        show_edge=True,
+    )
+    for col in df.columns:
+        table.add_column(str(col), overflow="fold")
+    for row in df.itertuples(index=False):
+        table.add_row(*[str(v) if v is not None else "" for v in row])
+    return table
+
+
+# ---------------------------------------------------------------------------
+# NIfTI helpers
+# ---------------------------------------------------------------------------
+
+
+def _result_to_nifti(
+    df: pd.DataFrame, template_path: Optional[str] = None
+) -> "nibabel.Nifti1Image":
+    """Convert a DataFrame with voxel coordinates into a NIfTI image.
+
+    Expects columns named (i, j, k) or similar 3D coordinate triple and
+    an optional value/label column.  If *template_path* is provided the
+    output image uses that template's affine and shape; otherwise an
+    identity-affine 256×256×256 volume is created.
+    """
+    import nibabel as nib
+
+    # Try to detect coordinate columns
+    col_lower = {c.lower(): c for c in df.columns}
+    i_col = col_lower.get("i")
+    j_col = col_lower.get("j")
+    k_col = col_lower.get("k")
+
+    if i_col is None or j_col is None or k_col is None:
+        # Fallback: use first three numeric columns
+        num_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+        if len(num_cols) >= 3:
+            i_col, j_col, k_col = num_cols[:3]
+
+    if i_col is None:
+        raise ValueError(
+            "Cannot determine voxel coordinates: no (i, j, k) or numeric columns found."
+        )
+
+    # Determine value column (anything that isn't a coordinate)
+    coord_cols = {i_col, j_col, k_col}
+    val_cols = [c for c in df.columns if c not in coord_cols]
+
+    # Load or create template volume
+    if template_path:
+        ref = nib.load(template_path)
+        shape = ref.shape[:3]
+        affine = ref.affine
+    else:
+        shape = (256, 256, 256)
+        affine = np.eye(4)
+
+    data = np.zeros(shape, dtype=np.float32)
+
+    coords = df[[i_col, j_col, k_col]].values.astype(int)
+    if val_cols:
+        values = df[val_cols[0]].values.astype(float)
+    else:
+        values = np.ones(len(df), dtype=np.float32)
+
+    # Clip to volume bounds
+    for idx in range(len(coords)):
+        ci, cj, ck = coords[idx]
+        if 0 <= ci < shape[0] and 0 <= cj < shape[1] and 0 <= ck < shape[2]:
+            data[ci, cj, ck] = values[idx]
+
+    return nib.Nifti1Image(data, affine)
+
+
+def _view_nifti(path: str) -> None:
+    """Open a NIfTI image using nilearn plotting (saves a PNG to temp dir)."""
+    try:
+        from nilearn import plotting
+    except ImportError:
+        _console.print("[red]nilearn is required for visualisation.[/red]")
+        return
+
+    path = os.path.expanduser(path)
+    if not os.path.isfile(path):
+        _console.print(f"[red]File not found: {path}[/red]")
+        return
+
+    tmp_png = tempfile.mktemp(suffix=".png", prefix="neurolang_view_")
+    try:
+        display = plotting.plot_img(
+            path,
+            display_mode="ortho",
+            cut_coords=None,
+            black_bg=True,
+            cmap="cold_hot",
+        )
+        display.savefig(tmp_png, dpi=150)
+        display.close()
+        _console.print(f"[green]Saved visualisation to: {tmp_png}[/green]")
+        # Try to open with system viewer
+        import subprocess
+        subprocess.Popen(["open", tmp_png] if sys.platform == "darwin" else ["xdg-open", tmp_png])
+        _console.print(f"[dim]Viewing: {tmp_png}[/dim]")
+    except Exception as exc:
+        _console.print(f"[red]Visualisation failed: {exc}[/red]")
+
+
+# ---------------------------------------------------------------------------
+# Result formatting (reuses cli.py helpers where possible)
+# ---------------------------------------------------------------------------
+
+
+def _rename_unnamed_columns(df, column_names):
+    """Replace auto-generated column names with *column_names* when safe."""
+    if column_names is not None and len(column_names) == len(df.columns):
+        unnamed = all(
+            isinstance(c, int)
+            or (isinstance(c, str) and c.startswith("c"))
+            for c in df.columns
+        )
+        if unnamed:
+            df.columns = column_names
+    return df
+
+
+def _format_as_df(result, column_names=None):
+    """Convert a query result to a pandas DataFrame, or None on failure."""
+    if result is None:
+        return None
+    if isinstance(result, bool):
+        # Boolean result: wrap in a tiny DataFrame
+        return pd.DataFrame({"result": ["true" if result else "false"]})
+
+    try:
+        # Unwrap Constant -> concrete set
+        if hasattr(result, "value") and hasattr(result.value, "unwrap"):
+            inner = result.value.unwrap()
+            if hasattr(inner, "as_pandas_dataframe"):
+                return _rename_unnamed_columns(inner.as_pandas_dataframe(), column_names)
+            result = inner
+
+        if hasattr(result, "columns") and len(result.columns) > 0:
+            return _rename_unnamed_columns(pd.DataFrame(iter(result), columns=result.columns), column_names)
+        rows = list(iter(result))
+        if not rows:
+            return pd.DataFrame()
+        arity = result.arity if hasattr(result, "arity") else len(rows[0])
+        return _rename_unnamed_columns(pd.DataFrame(rows, columns=[f"c{i}" for i in range(arity)]), column_names)
+    except Exception as exc:
+        _console.print(f"[yellow]Warning: result formatting failed: {exc}[/yellow]")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# The Interactive TUI App
+# ---------------------------------------------------------------------------
+
+
+class InteractiveTuiApp:
+    """Interactive NeuroLang REPL with autocomplete, rich rendering, NIfTI support."""
+
+    def __init__(
+        self,
+        engine_name: str = "neurosynth",
+        data_dir: str = "neurolang_data",
+        resolution: Optional[float] = None,
+        history_path: Optional[str] = None,
+        squall_mode: bool = False,
+        sort_specs: Optional[list[str]] = None,
+    ):
+        self.engine_name = engine_name
+        self.data_dir = Path(data_dir)
+        self.resolution = resolution
+        self.squall_mode = squall_mode
+        self.sort_specs = sort_specs or []
+
+        # State
+        self._nl: Optional[NeurolangPDL] = None
+        self._engine_built = False
+        self._last_df: Optional[pd.DataFrame] = None
+        self._last_result_type: Optional[str] = None  # 'single' or 'dict'
+
+        # History
+        history_path = history_path or str(Path.home() / ".neurolang_query_history")
+        self._history = FileHistory(history_path)
+
+        # Key bindings
+        self._kb = KeyBindings()
+
+        @self._kb.add("escape", "enter")  # Alt+Enter / Meta+Enter
+        @self._kb.add("c-j", filter=~HasSearch())
+        def _(event):
+            """Insert newline instead of submitting."""
+            event.current_buffer.insert_text("\n")
+
+        # Completer
+        try:
+            self._completer = NeuroLangReplCompleter(LarkCompleter(COMPILED_GRAMMAR))
+        except Exception as exc:
+            _console.print(f"[yellow]Warning: autocomplete init failed: {exc}[/yellow]")
+            self._completer = None
+
+        # Session
+        self._session = PromptSession(
+            history=self._history,
+            key_bindings=self._kb,
+            completer=self._completer,
+            complete_while_typing=True,
+            multiline=False,
+            enable_open_in_editor=True,
+            vi_mode=False,
+        )
+
+    # -----------------------------------------------------------------------
+    # Engine lazy-build
+    # -----------------------------------------------------------------------
+
+    def _ensure_engine(self) -> None:
+        if self._engine_built:
+            return
+        if self.engine_name not in engine_registry.list_engine_names():
+            available = ", ".join(engine_registry.list_engine_names())
+            _console.print(
+                f"[red]Unknown engine {self.engine_name!r}.[/red] "
+                f"Available: {available}"
+            )
+            raise SystemExit(1)
+        _console.print(f"[dim]Building engine {self.engine_name!r} ...[/dim]")
+        self._nl = engine_registry.build_engine(
+            self.engine_name, self.data_dir, self.resolution
+        )
+        self._engine_built = True
+        _console.print("[green]Engine ready.[/green]")
+
+    # -----------------------------------------------------------------------
+    # Query execution
+    # -----------------------------------------------------------------------
+
+    def _execute_and_display(self, program: str) -> None:
+        """Parse, execute, and render a Datalog / SQUALL query."""
+        self._ensure_engine()
+
+        sort_by = []
+        for spec in self.sort_specs:
+            parts = spec.split(":", maxsplit=1)
+            col = parts[0]
+            ascending = True
+            if len(parts) == 2 and parts[1].lower() == "desc":
+                ascending = False
+            sort_by.append((col, ascending))
+
+        t0 = time.perf_counter()
+        try:
+            if self.squall_mode:
+                result = self._nl.execute_squall_program(program)
+            else:
+                result = self._nl.execute_datalog_program(program)
+        except Exception as exc:
+            _console.print(f"[red]Query error:[/red] {exc}")
+            return
+
+        elapsed = time.perf_counter() - t0
+
+        if result is None:
+            _console.print("[dim](no result)[/dim]")
+            self._last_df = None
+            self._last_result_type = None
+            return
+
+        if isinstance(result, bool):
+            _console.print("[green]true[/green]" if result else "[red]false[/red]")
+            self._last_df = _format_as_df(result)
+            self._last_result_type = "single"
+            return
+
+        if isinstance(result, dict):
+            self._last_result_type = "dict"
+            first = True
+            for key, sub_result in result.items():
+                df = _format_as_df(sub_result)
+                if df is not None and not df.empty:
+                    if first:
+                        _console.print(f"\n[bold magenta]── {key} ──[/bold magenta]")
+                        first = False
+                    else:
+                        _console.print(f"\n[bold magenta]── {key} ──[/bold magenta]")
+                    if sort_by:
+                        valid = [(c, a) for c, a in sort_by if c in df.columns]
+                        if valid:
+                            cols, asc = zip(*valid)
+                            df = df.sort_values(by=list(cols), ascending=list(asc))
+                    _console.print(_df_to_rich_table(df, title=key))
+                    self._last_df = df
+        else:
+            self._last_result_type = "single"
+            df = _format_as_df(result)
+            if df is not None:
+                if sort_by:
+                    valid = [(c, a) for c, a in sort_by if c in df.columns]
+                    if valid:
+                        cols, asc = zip(*valid)
+                        df = df.sort_values(by=list(cols), ascending=list(asc))
+                if df.empty:
+                    _console.print("[dim](empty)[/dim]")
+                else:
+                    _console.print(_df_to_rich_table(df))
+                self._last_df = df
+            else:
+                _console.print(str(result))
+
+        _console.print(f"\n[dim]Query completed in {elapsed:.2f} s[/dim]")
+
+    # -----------------------------------------------------------------------
+    # Dot-command handlers
+    # -----------------------------------------------------------------------
+
+    def _cmd_help(self) -> None:
+        _console.print(Panel(HELP_TEXT, border_style="cyan"))
+
+    def _cmd_engines(self) -> None:
+        engine_registry.show_engines()
+
+    def _cmd_sets(self) -> None:
+        self._ensure_engine()
+        from neurolang.datalog import WrappedRelationalAlgebraSet
+        st = self._nl.program_ir.symbol_table
+        sets_found = []
+        for sym_name, sym_val in st.items():
+            val = getattr(sym_val, "value", sym_val)
+            if not isinstance(val, WrappedRelationalAlgebraSet):
+                continue
+            ra_set = val.unwrap()
+            arity = ra_set.arity
+            columns = list(ra_set.columns)
+            try:
+                size = len(ra_set)
+            except Exception:
+                size = "?"
+            clean_name = getattr(sym_name, "name", str(sym_name))
+            sets_found.append((clean_name, columns, size, arity))
+        if not sets_found:
+            _console.print("  [dim](no RA sets registered)[/dim]")
+            return
+        table = Table(title="RA Sets", box=box.ROUNDED, header_style="bold cyan")
+        table.add_column("Set")
+        table.add_column("Columns")
+        table.add_column("Rows")
+        table.add_column("Arity")
+        for name, cols, size, arity in sorted(sets_found, key=lambda x: x[0]):
+            table.add_row(str(name), str(cols), str(size), str(arity))
+        _console.print(table)
+        _console.print(f"\n[dim]Total RA sets: {len(sets_found)}[/dim]")
+
+    def _cmd_predicates(self) -> None:
+        cfg = engine_registry.get_engine_config(self.engine_name)
+        _console.print(f"\n[bold]Engine:[/bold] {self.engine_name}")
+        _console.print(f"  {cfg.get('description', '')}")
+        predicates = engine_registry.get_predicates(self.engine_name)
+        if not predicates:
+            _console.print("\n  [dim](no predicate metadata declared)[/dim]")
+            return
+        table = Table(title="Available Predicates", box=box.ROUNDED, header_style="bold cyan")
+        table.add_column("Predicate")
+        table.add_column("Columns")
+        table.add_column("Description")
+        for pname, info in predicates.items():
+            cols = ", ".join(info.get("columns", []))
+            desc = info.get("description", "")
+            table.add_row(f"{pname}({cols})", cols, desc)
+        _console.print(table)
+
+    def _cmd_save(self, args: str) -> None:
+        if self._last_df is None:
+            _console.print("[yellow]Nothing to save — run a query first.[/yellow]")
+            return
+
+        path = args.strip()
+        if not path:
+            _console.print("[yellow]Usage: .save <path>  or  .save <path>.nii[/yellow]")
+            return
+
+        path = os.path.expanduser(path)
+        parent = os.path.dirname(path) or "."
+        os.makedirs(parent, exist_ok=True)
+
+        if path.endswith(".nii"):
+            try:
+                img = _result_to_nifti(self._last_df)
+                import nibabel as nib
+                nib.save(img, path)
+                _console.print(f"[green]NIfTI saved to: {path}[/green]")
+            except Exception as exc:
+                _console.print(f"[red]NIfTI save failed: {exc}[/red]")
+        else:
+            try:
+                self._last_df.to_csv(path, index=False)
+                _console.print(f"[green]CSV saved to: {path}[/green]")
+            except Exception as exc:
+                _console.print(f"[red]Save failed: {exc}[/red]")
+
+    def _cmd_view(self, args: str) -> None:
+        path = args.strip()
+        if not path:
+            _console.print("[yellow]Usage: .view <path>.nii[/yellow]")
+            return
+        path = os.path.expanduser(path)
+        if not os.path.isfile(path):
+            _console.print(f"[red]File not found: {path}[/red]")
+            return
+        _view_nifti(path)
+
+    def _cmd_mode(self, args: str) -> None:
+        mode = args.strip().lower()
+        if mode == "datalog":
+            self.squall_mode = False
+            _console.print("[green]Mode: Datalog[/green]")
+        elif mode == "squall":
+            self.squall_mode = True
+            _console.print("[green]Mode: SQUALL[/green]")
+        else:
+            _console.print(f"[yellow]Unknown mode {mode!r}. Use 'datalog' or 'squall'.[/yellow]")
+
+    def _handle_dot_command(self, line: str) -> bool:
+        """Handle a dot-command.  Returns True if the session should continue."""
+        cmd = line.strip()
+        parts = cmd.split(None, 1)
+        verb = parts[0].lower() if parts else ""
+        rest = parts[1] if len(parts) > 1 else ""
+
+        handlers = {
+            ".help": lambda: self._cmd_help(),
+            ".engines": lambda: self._cmd_engines(),
+            ".sets": lambda: self._cmd_sets(),
+            ".predicates": lambda: self._cmd_predicates(),
+            ".save": lambda: self._cmd_save(rest),
+            ".view": lambda: self._cmd_view(rest),
+            ".mode": lambda: self._cmd_mode(rest),
+            ".quit": lambda: sys.exit(0),
+            ".exit": lambda: sys.exit(0),
+        }
+        handler = handlers.get(verb)
+        if handler:
+            handler()
+        else:
+            _console.print(f"[yellow]Unknown command: {verb}. Try .help[/yellow]")
+        return True
+
+    # -----------------------------------------------------------------------
+    # Prompt style
+    # -----------------------------------------------------------------------
+
+    def _get_prompt(self) -> str:
+        mode = "SQ" if self.squall_mode else "DL"
+        return f"nl({self.engine_name}:{mode})> "
+
+    # -----------------------------------------------------------------------
+    # Main loop
+    # -----------------------------------------------------------------------
+
+    def run(self) -> None:
+        """Start the interactive REPL."""
+        _console.print()
+        _console.print(Panel.fit(
+            "[bold yellow]NeuroLang Interactive Query REPL[/bold yellow]\n"
+            "Type [green].help[/green] for commands.  "
+            "Ctrl+D or [green].quit[/green] to exit.",
+            border_style="cyan",
+        ))
+        _console.print()
+
+        # Show default engine info
+        try:
+            self._ensure_engine()
+            cfg = engine_registry.get_engine_config(self.engine_name)
+            _console.print(f"[dim]Engine: {self.engine_name} — {cfg.get('description', '')}[/dim]")
+            _console.print(f"[dim]Mode: {'SQUALL' if self.squall_mode else 'Datalog'}[/dim]")
+        except Exception as exc:
+            _console.print(f"[yellow]Engine pre-load skipped: {exc}[/yellow]")
+
+        while True:
+            try:
+                with patch_stdout():
+                    line = self._session.prompt(self._get_prompt())
+            except (EOFError, KeyboardInterrupt):
+                _console.print("\n[dim]Goodbye.[/dim]")
+                break
+
+            if not line or not line.strip():
+                continue
+
+            # Dot commands
+            if line.startswith("."):
+                self._handle_dot_command(line)
+                continue
+
+            # Execute as query
+            program = line.strip()
+            self._execute_and_display(program)
+
+
+def main(
+    engine_name: str = "neurosynth",
+    data_dir: str = "neurolang_data",
+    resolution: Optional[float] = None,
+    squall_mode: bool = False,
+    sort_specs: Optional[list[str]] = None,
+) -> None:
+    """Entry point for the interactive TUI launched from the CLI."""
+    app = InteractiveTuiApp(
+        engine_name=engine_name,
+        data_dir=data_dir,
+        resolution=resolution,
+        squall_mode=squall_mode,
+        sort_specs=sort_specs,
+    )
+    app.run()

--- a/neurolang/utils/interactive_tui.py
+++ b/neurolang/utils/interactive_tui.py
@@ -36,6 +36,7 @@ from neurolang.frontend.datalog.pretty_printer import DatalogPrettyPrinter
 from neurolang.frontend.datalog.squall_syntax_lark import (
     parser as squall_parser, SquallProgram,
 )
+from neurolang.expressions import Symbol as ExprSymbol
 from neurolang.logic import Union as LogicUnion
 from neurolang.utils import engine_registry
 from neurolang.utils.interactive_parsing import LarkCompleter, TERMINALS_TO_CATEGORIES, CATEGORIES
@@ -50,6 +51,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.lexers import Lexer
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.filters import HasSearch
+from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.styles import Style
 
 import rich
@@ -68,6 +70,8 @@ DOT_COMMANDS = {
     ".engines": "List available dataset engines",
     ".sets": "List loaded RA sets (EDB relations)",
     ".predicates": "List available predicates for the current engine",
+    ".idb": "List intensional (session-defined) predicates",
+    ".clear": "Clear intensional predicates\n  .clear              — clear all session-defined IDB predicates\n  .clear <predicate>  — clear a specific session-defined IDB predicate",
     ".save": "Save last result to a file\n  .save <path>        — save as CSV\n  .save <path>.nii    — save result voxel data as NIfTI",
     ".view": "Visualise a NIfTI file (uses nilearn plotting)\n  .view <path>.nii",
     ".mode": "Toggle language mode or vi/emacs editing mode\n  .mode datalog\n  .mode squall\n  .mode vi\n  .mode emacs",
@@ -537,6 +541,10 @@ class InteractiveTuiApp:
         # Collect predicates from the engine's symbol table and YAML metadata
         self._engine_predicates = self._collect_predicates()
         self._rebuild_completer()
+        self._open_session_scope()
+
+    def _open_session_scope(self) -> None:
+        self._nl.program_ir.push_scope()
 
     def _collect_predicates(self) -> set[str]:
         """Collect predicate names from the engine's symbol table and YAML config."""
@@ -714,6 +722,66 @@ class InteractiveTuiApp:
             table.add_row(f"{pname}({cols})", cols, desc)
         _console.print(table)
 
+    def _cmd_idb(self) -> None:
+        self._ensure_engine()
+        idb = self._nl.program_ir.intensional_database()
+        session_symbols = self._current_scope_idb_symbols()
+        if not session_symbols:
+            _console.print("  [dim](no session-defined IDB predicates)[/dim]")
+            return
+        table = Table(
+            title="Session IDB predicates",
+            box=box.ROUNDED,
+            header_style="bold cyan",
+        )
+        table.add_column("Predicate")
+        table.add_column("Rules")
+        table.add_column("Arity")
+        for sym in sorted(session_symbols, key=lambda s: s.name):
+            rules = idb[sym]
+            arity = len(rules.formulas[0].consequent.args)
+            table.add_row(sym.name, str(len(rules.formulas)), str(arity))
+        _console.print(table)
+        _console.print(f"\n[dim]Total session IDB predicates: {len(session_symbols)}[/dim]")
+
+    def _current_scope_idb_symbols(self) -> set:
+        self._ensure_engine()
+        st = self._nl.program_ir.symbol_table
+        return {
+            sym
+            for sym in self._nl.program_ir.intensional_database()
+            if sym in st._symbols
+        }
+
+    def _cmd_clear(self, args: str) -> None:
+        self._ensure_engine()
+        target = args.strip()
+        if not target:
+            self._nl.program_ir.pop_scope()
+            self._open_session_scope()
+            _console.print("[green]All session-defined IDB predicates cleared.[/green]")
+            return
+
+        sym = ExprSymbol(target)
+        st = self._nl.program_ir.symbol_table
+        if sym not in st:
+            _console.print(f"[yellow]Predicate {target!r} is not defined.[/yellow]")
+            return
+        if sym not in st._symbols:
+            _console.print(
+                f"[yellow]Predicate {target!r} is part of the engine; "
+                "only session-defined IDB predicates can be cleared.[/yellow]"
+            )
+            return
+        value = st[sym]
+        if not isinstance(value, DatalogUnion):
+            _console.print(
+                f"[yellow]Predicate {target!r} is not an IDB predicate.[/yellow]"
+            )
+            return
+        del st[sym]
+        _console.print(f"[green]IDB predicate {target!r} cleared.[/green]")
+
     def _cmd_save(self, args: str) -> None:
         if self._last_df is None:
             _console.print("[yellow]Nothing to save — run a query first.[/yellow]")
@@ -764,10 +832,10 @@ class InteractiveTuiApp:
             self._rebuild_completer()
             _console.print("[green]Mode: SQUALL[/green]")
         elif mode == "vi":
-            self._session.vi_mode = True
+            self._session.editing_mode = EditingMode.VI
             _console.print("[green]Vi mode enabled[/green]")
         elif mode == "emacs":
-            self._session.vi_mode = False
+            self._session.editing_mode = EditingMode.EMACS
             _console.print("[green]Emacs mode enabled[/green]")
         else:
             _console.print(f"[yellow]Unknown mode {mode!r}. Use 'datalog', 'squall', 'vi', or 'emacs'.[/yellow]")
@@ -838,6 +906,8 @@ class InteractiveTuiApp:
             ".engines": lambda: self._cmd_engines(),
             ".sets": lambda: self._cmd_sets(),
             ".predicates": lambda: self._cmd_predicates(),
+            ".idb": lambda: self._cmd_idb(),
+            ".clear": lambda: self._cmd_clear(rest),
             ".save": lambda: self._cmd_save(rest),
             ".view": lambda: self._cmd_view(rest),
             ".mode": lambda: self._cmd_mode(rest),
@@ -885,7 +955,7 @@ class InteractiveTuiApp:
             result_info = "single"
         else:
             result_info = "—"
-        vi = "VI" if self._session.vi_mode else "EM"
+        vi = "VI" if self._session.editing_mode == EditingMode.VI else "EM"
         return HTML(
             f"<b>nl({self.engine_name}:{mode})</b>  "
             f"preds:{pred_count}  "

--- a/neurolang/utils/interactive_tui.py
+++ b/neurolang/utils/interactive_tui.py
@@ -81,48 +81,96 @@ The tab key triggers grammar-aware autocompletion.
 """
 
 # ---------------------------------------------------------------------------
-# Custom prompt_toolkit Completer wrapping LarkCompleter
+# SQUALL keywords used for keyword-based completion (Earley parser does not
+# support parse_interactive(), so we fall back to plain keyword matching).
+# ---------------------------------------------------------------------------
+
+SQUALL_KEYWORDS = [
+    "define", "as", "obtain", "every", "a", "an", "the",
+    "in", "where", "that", "with", "without", "if", "then",
+    "and", "or", "not", "for", "of", "from", "to", "by",
+    "at", "on", "is", "are", "has", "have", "there",
+    "probability", "conditioned", "inferred", "choose",
+    "peaks", "voxels", "studies", "terms", "experiments",
+    "reported", "in", "that", "which", "atlas",
+    "all", "each", "some", "no", "any",
+    "most", "few", "both", "neither",
+]
+
+# ---------------------------------------------------------------------------
+# Custom prompt_toolkit Completer — multi-source: grammar + predicates + keywords
 # ---------------------------------------------------------------------------
 
 
 class NeuroLangReplCompleter(Completer):
-    """prompt_toolkit Completer backed by the Lark grammar completer."""
+    """prompt_toolkit Completer combining grammar completions + engine predicates + dot commands."""
 
-    def __init__(self, lark_completer: LarkCompleter):
+    def __init__(
+        self,
+        lark_completer: Optional[LarkCompleter] = None,
+        engine_predicates: Optional[set[str]] = None,
+        squall_keywords: Optional[list[str]] = None,
+    ):
         self._lark = lark_completer
+        self._predicates = engine_predicates or set()
+        self._squall_keywords = squall_keywords or []
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
-        # Dot commands get literal completion
+
+        # 1. Dot commands
         if text.startswith("."):
             for cmd in DOT_COMMANDS:
                 if cmd.startswith(text):
                     yield Completion(cmd, start_position=-len(text))
             return
 
-        try:
-            result = self._lark.complete(text)
-        except Exception:
-            return
+        # 2. Grammar completions (Datalog LALR mode)
+        if self._lark is not None:
+            try:
+                result = self._lark.complete(text)
+                seen = set()
+                for category_key, container in result.token_options.items():
+                    for value in container.get("values", set()):
+                        if not value or value in seen:
+                            continue
+                        seen.add(value)
+                        display = value
+                        if value.startswith("<") and value.endswith(">"):
+                            display = value[1:-1]
+                        yield Completion(
+                            value,
+                            start_position=-len(result.prefix),
+                            display=display,
+                            display_meta=category_key,
+                        )
+            except Exception:
+                pass
 
-        opts = result.token_options
-        # Flatten token_options into completions
-        seen = set()
-        for category_key, container in opts.items():
-            for value in container.get("values", set()):
-                if not value or value in seen:
-                    continue
-                seen.add(value)
-                # Strip angle brackets for display
-                display = value
-                if value.startswith("<") and value.endswith(">"):
-                    display = value[1:-1]
-                yield Completion(
-                    value,
-                    start_position=-len(result.prefix),
-                    display=display,
-                    display_meta=category_key,
-                )
+        # 3. Engine predicate completions (both modes)
+        word_start = text.rfind(" ") + 1 if " " in text else 0
+        prefix = text[word_start:]
+        # Only suggest predicates when it looks like we're typing an identifier
+        if prefix and (prefix[0].isalpha() or prefix[0] == "_"):
+            for pred in sorted(self._predicates):
+                if pred.startswith(prefix):
+                    yield Completion(
+                        pred,
+                        start_position=-len(prefix),
+                        display=pred,
+                        display_meta="predicate",
+                    )
+
+        # 4. SQUALL keywords (when no lark completer — squall mode)
+        if self._lark is None:
+            for kw in self._squall_keywords:
+                if kw.startswith(prefix):
+                    yield Completion(
+                        kw,
+                        start_position=-len(prefix),
+                        display=kw,
+                        display_meta="keyword",
+                    )
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +367,8 @@ class InteractiveTuiApp:
         self._engine_built = False
         self._last_df: Optional[pd.DataFrame] = None
         self._last_result_type: Optional[str] = None  # 'single' or 'dict'
+        self._engine_predicates: set[str] = set()
+        self._squall_keywords = SQUALL_KEYWORDS
 
         # History
         history_path = history_path or str(Path.home() / ".neurolang_query_history")
@@ -333,9 +383,13 @@ class InteractiveTuiApp:
             """Insert newline instead of submitting."""
             event.current_buffer.insert_text("\n")
 
-        # Completer
+        # Completer (initial: Datalog LALR mode)
         try:
-            self._completer = NeuroLangReplCompleter(LarkCompleter(COMPILED_GRAMMAR))
+            self._completer = NeuroLangReplCompleter(
+                lark_completer=LarkCompleter(COMPILED_GRAMMAR),
+                engine_predicates=self._engine_predicates,
+                squall_keywords=self._squall_keywords,
+            )
         except Exception as exc:
             _console.print(f"[yellow]Warning: autocomplete init failed: {exc}[/yellow]")
             self._completer = None
@@ -371,6 +425,47 @@ class InteractiveTuiApp:
         )
         self._engine_built = True
         _console.print("[green]Engine ready.[/green]")
+
+        # Collect predicates from the engine's symbol table and YAML metadata
+        self._engine_predicates = self._collect_predicates()
+        self._rebuild_completer()
+
+    def _collect_predicates(self) -> set[str]:
+        """Collect predicate names from the engine's symbol table and YAML config."""
+        preds: set[str] = set()
+        if self._nl is None:
+            return preds
+        st = self._nl.program_ir.symbol_table
+        for sym_name, sym_val in st.items():
+            val = getattr(sym_val, "value", sym_val)
+            if isinstance(val, WrappedRelationalAlgebraSet):
+                name = getattr(sym_name, "name", str(sym_name))
+                preds.add(name)
+        # Also add YAML-declared predicates from engine_registry
+        try:
+            yaml_preds = engine_registry.get_predicates(self.engine_name)
+            preds.update(yaml_preds.keys())
+        except Exception:
+            pass
+        return preds
+
+    def _rebuild_completer(self) -> None:
+        """Rebuild the prompt_toolkit completer for the current mode."""
+        if self.squall_mode:
+            lark = None
+        else:
+            try:
+                lark = LarkCompleter(COMPILED_GRAMMAR)
+            except Exception:
+                lark = None
+
+        self._completer = NeuroLangReplCompleter(
+            lark_completer=lark,
+            engine_predicates=self._engine_predicates,
+            squall_keywords=self._squall_keywords,
+        )
+        # Update the session's completer
+        self._session.completer = self._completer
 
     # -----------------------------------------------------------------------
     # Query execution
@@ -553,9 +648,11 @@ class InteractiveTuiApp:
         mode = args.strip().lower()
         if mode == "datalog":
             self.squall_mode = False
+            self._rebuild_completer()
             _console.print("[green]Mode: Datalog[/green]")
         elif mode == "squall":
             self.squall_mode = True
+            self._rebuild_completer()
             _console.print("[green]Mode: SQUALL[/green]")
         else:
             _console.print(f"[yellow]Unknown mode {mode!r}. Use 'datalog' or 'squall'.[/yellow]")

--- a/neurolang/utils/tests/test_interactive_tui.py
+++ b/neurolang/utils/tests/test_interactive_tui.py
@@ -1,0 +1,302 @@
+"""Tests for the interactive TUI module."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from neurolang.utils.interactive_tui import (
+    _df_to_rich_table,
+    _format_as_df,
+    _rename_unnamed_columns,
+    _result_to_nifti,
+    InteractiveTuiApp,
+    NeuroLangReplCompleter,
+    DOT_COMMANDS,
+)
+from neurolang.utils.interactive_parsing import LarkCompleter
+from neurolang.frontend.datalog.standard_syntax import COMPILED_GRAMMAR
+from neurolang.datalog import WrappedRelationalAlgebraSet
+from neurolang.utils.relational_algebra_set.pandas import (
+    RelationalAlgebraSet,
+    NamedRelationalAlgebraFrozenSet,
+)
+from neurolang import expressions as ir
+
+
+# ---------------------------------------------------------------------------
+# NeuroLangReplCompleter
+# ---------------------------------------------------------------------------
+
+
+class TestNeuroLangReplCompleter:
+    @pytest.fixture
+    def completer(self):
+        try:
+            lark = LarkCompleter(COMPILED_GRAMMAR)
+        except Exception:
+            lark = None
+        return NeuroLangReplCompleter(lark)
+
+    def test_dot_command_completions(self, completer):
+        """Dot commands should complete partially typed commands."""
+        # Mock a document-like object
+        class FakeDoc:
+            text_before_cursor = ".h"
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        assert len(completions) > 0
+        # Should complete to .help
+        assert any(c.text == ".help" for c in completions)
+
+    def test_dot_command_partial_engines(self, completer):
+        class FakeDoc:
+            text_before_cursor = ".eng"
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        assert any(c.text == ".engines" for c in completions)
+
+    def test_dot_command_empty_dot(self, completer):
+        """Typing just '.' should suggest all dot commands."""
+        class FakeDoc:
+            text_before_cursor = "."
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        for cmd in DOT_COMMANDS:
+            assert any(c.text == cmd for c in completions), (
+                f"Missing dot command {cmd!r} in completions"
+            )
+
+    def test_non_dot_does_not_crash(self, completer):
+        """Non-dot input should call the Lark completer without crashing."""
+        class FakeDoc:
+            text_before_cursor = "ans(x) :- term"
+
+        # Just ensure no exception is raised
+        completions = list(completer.get_completions(FakeDoc(), None))
+        # May or may not return completions depending on Lark grammar state,
+        # but should not crash
+        assert isinstance(completions, list)
+
+
+# ---------------------------------------------------------------------------
+# _df_to_rich_table
+# ---------------------------------------------------------------------------
+
+
+class TestDfToRichTable:
+    def test_basic_table(self):
+        df = pd.DataFrame({"x": [1, 2], "y": ["a", "b"]})
+        table = _df_to_rich_table(df, title="Test")
+        assert table.title == "Test"
+        # Rich Table stores columns; check they exist
+        assert len(table.columns) == 2
+        assert table.columns[0].header == "x"
+        assert table.columns[1].header == "y"
+
+    def test_empty_dataframe(self):
+        df = pd.DataFrame({"x": pd.Series([], dtype=int)})
+        table = _df_to_rich_table(df)
+        assert len(table.columns) == 1
+        assert table.columns[0].header == "x"
+
+    def test_single_row(self):
+        df = pd.DataFrame({"col": [42]})
+        table = _df_to_rich_table(df)
+        assert len(table.columns) == 1
+        assert table.columns[0].header == "col"
+
+    def test_multiple_columns(self):
+        df = pd.DataFrame({"a": [1], "b": [2.5], "c": ["x"]})
+        table = _df_to_rich_table(df)
+        assert len(table.columns) == 3
+        headers = [c.header for c in table.columns]
+        assert headers == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# _rename_unnamed_columns
+# ---------------------------------------------------------------------------
+
+
+class TestRenameUnnamedColumns:
+    def test_renames_int_columns(self):
+        df = pd.DataFrame({0: [1, 2], 1: [3, 4]})
+        result = _rename_unnamed_columns(df, ["x", "y"])
+        assert list(result.columns) == ["x", "y"]
+
+    def test_renames_c0_style_columns(self):
+        df = pd.DataFrame({"c0": [1], "c1": [2]})
+        result = _rename_unnamed_columns(df, ["a", "b"])
+        assert list(result.columns) == ["a", "b"]
+
+    def test_preserves_named_columns(self):
+        df = pd.DataFrame({"name": [1], "value": [2]})
+        result = _rename_unnamed_columns(df, ["x", "y"])
+        assert list(result.columns) == ["name", "value"]
+
+    def test_ignores_wrong_length(self):
+        df = pd.DataFrame({0: [1]})
+        result = _rename_unnamed_columns(df, ["a", "b", "c"])
+        assert list(result.columns) == [0]
+
+    def test_handles_mixed_named_and_unnamed(self):
+        """When only some columns are named, rename is not applied."""
+        df = pd.DataFrame({0: [1], "label": ["x"]})
+        result = _rename_unnamed_columns(df, ["a", "b"])
+        assert list(result.columns) == [0, "label"]
+
+    def test_no_column_names_none(self):
+        df = pd.DataFrame({0: [1]})
+        result = _rename_unnamed_columns(df, None)
+        assert list(result.columns) == [0]
+
+
+# ---------------------------------------------------------------------------
+# _format_as_df
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAsDf:
+    def test_none_returns_none(self):
+        assert _format_as_df(None) is None
+
+    def test_true_returns_df(self):
+        df = _format_as_df(True)
+        assert df is not None
+        assert df.iloc[0, 0] == "true"
+
+    def test_false_returns_df(self):
+        df = _format_as_df(False)
+        assert df is not None
+        assert df.iloc[0, 0] == "false"
+
+    def test_empty_result(self):
+        """An empty RA set should produce an empty DataFrame."""
+        ras = RelationalAlgebraSet()
+        df = _format_as_df(ras)
+        assert df is not None
+        assert df.empty
+
+    def test_nonempty_unnamed_set(self):
+        ras = RelationalAlgebraSet()
+        ras.add((1, "a"))
+        ras.add((2, "b"))
+        df = _format_as_df(ras)
+        assert df is not None
+        assert len(df) == 2
+        # Unnamed sets get integer column indices from RangeIndex
+        assert list(df.columns) == [0, 1]
+
+    def test_named_set(self):
+        nras = NamedRelationalAlgebraFrozenSet(
+            columns=("x", "y"), iterable=[(1, "a")]
+        )
+        df = _format_as_df(nras)
+        assert df is not None
+        assert list(df.columns) == ["x", "y"]
+        assert df.iloc[0, 0] == 1
+
+    def test_wrapped_constant(self):
+        """Test with a Constant wrapping a WrappedRelationalAlgebraSet."""
+        inner = RelationalAlgebraSet()
+        inner.add((42,))
+        wrapped = WrappedRelationalAlgebraSet(inner)
+        result = ir.Constant(wrapped)
+        df = _format_as_df(result, column_names=["val"])
+        assert df is not None
+        assert "val" in df.columns
+        assert df.iloc[0, 0] == 42
+
+
+# ---------------------------------------------------------------------------
+# _result_to_nifti
+# ---------------------------------------------------------------------------
+
+
+class TestResultToNifti:
+    def test_basic_nifti_from_ij_columns(self):
+        """Using (i, j, k) columns should produce a valid Nifti1Image."""
+        df = pd.DataFrame({
+            "i": [10, 20],
+            "j": [30, 40],
+            "k": [50, 60],
+            "value": [1.0, 2.0],
+        })
+        img = _result_to_nifti(df)
+        import nibabel as nib
+        assert isinstance(img, nib.Nifti1Image)
+        assert img.shape == (256, 256, 256)
+        # Check values at coordinate positions
+        data = img.get_fdata()
+        assert data[10, 30, 50] == 1.0
+        assert data[20, 40, 60] == 2.0
+
+    def test_nifti_without_value_column(self):
+        """Without a value column, all voxels should be 1.0."""
+        df = pd.DataFrame({
+            "i": [5],
+            "j": [5],
+            "k": [5],
+        })
+        img = _result_to_nifti(df)
+        data = img.get_fdata()
+        assert data[5, 5, 5] == 1.0
+
+    def test_nifti_clips_out_of_bounds(self):
+        """Coordinates outside volume should be silently ignored."""
+        df = pd.DataFrame({
+            "i": [1000],
+            "j": [1000],
+            "k": [1000],
+            "value": [42.0],
+        })
+        img = _result_to_nifti(df)
+        data = img.get_fdata()
+        # Should not crash, value should be 0 (not set)
+        assert data[255, 255, 255] == 0.0
+
+    def test_nifti_raises_with_no_coords(self):
+        """No coordinate columns should raise."""
+        df = pd.DataFrame({"label": ["a"], "value": [1.0]})
+        with pytest.raises(
+            ValueError, match="Cannot determine voxel coordinates"
+        ):
+            _result_to_nifti(df)
+
+    def test_nifti_uses_fallback_numeric_cols(self):
+        """Fallback to first 3 numeric columns when no i/j/k found."""
+        df = pd.DataFrame({
+            "x": [0],
+            "y": [0],
+            "z": [0],
+            "val": [5.0],
+        })
+        img = _result_to_nifti(df)
+        data = img.get_fdata()
+        assert data[0, 0, 0] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# InteractiveTuiApp._get_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestInteractiveTuiAppPrompt:
+    def test_datalog_prompt(self):
+        app = InteractiveTuiApp(engine_name="neurosynth", squall_mode=False)
+        prompt = app._get_prompt()
+        assert "DL" in prompt
+        assert "neurosynth" in prompt
+
+    def test_squall_prompt(self):
+        app = InteractiveTuiApp(engine_name="destrieux", squall_mode=True)
+        prompt = app._get_prompt()
+        assert "SQ" in prompt
+        assert "destrieux" in prompt
+
+    def test_prompt_format(self):
+        app = InteractiveTuiApp(engine_name="test_engine")
+        prompt = app._get_prompt()
+        assert prompt.endswith("> ")
+        assert "nl(" in prompt
+        assert ")" in prompt

--- a/neurolang/utils/tests/test_interactive_tui.py
+++ b/neurolang/utils/tests/test_interactive_tui.py
@@ -4,6 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+prompt_toolkit = pytest.importorskip(
+    "prompt_toolkit", reason="prompt_toolkit is required for TUI tests"
+)
 from prompt_toolkit.document import Document
 
 from neurolang.utils.interactive_tui import (

--- a/neurolang/utils/tests/test_interactive_tui.py
+++ b/neurolang/utils/tests/test_interactive_tui.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from prompt_toolkit.document import Document
+
 from neurolang.utils.interactive_tui import (
     _df_to_rich_table,
     _format_as_df,
@@ -12,6 +14,7 @@ from neurolang.utils.interactive_tui import (
     InteractiveTuiApp,
     NeuroLangReplCompleter,
     DOT_COMMANDS,
+    SLASH_COMMANDS,
     SQUALL_KEYWORDS,
 )
 from neurolang.utils.interactive_parsing import LarkCompleter
@@ -40,28 +43,18 @@ class TestNeuroLangReplCompleter:
 
     def test_dot_command_completions(self, completer):
         """Dot commands should complete partially typed commands."""
-        # Mock a document-like object
-        class FakeDoc:
-            text_before_cursor = ".h"
-
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document(".h"), None))
         assert len(completions) > 0
         # Should complete to .help
         assert any(c.text == ".help" for c in completions)
 
     def test_dot_command_partial_engines(self, completer):
-        class FakeDoc:
-            text_before_cursor = ".eng"
-
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document(".eng"), None))
         assert any(c.text == ".engines" for c in completions)
 
     def test_dot_command_empty_dot(self, completer):
         """Typing just '.' should suggest all dot commands."""
-        class FakeDoc:
-            text_before_cursor = "."
-
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document("."), None))
         for cmd in DOT_COMMANDS:
             assert any(c.text == cmd for c in completions), (
                 f"Missing dot command {cmd!r} in completions"
@@ -69,11 +62,8 @@ class TestNeuroLangReplCompleter:
 
     def test_non_dot_does_not_crash(self, completer):
         """Non-dot input should call the Lark completer without crashing."""
-        class FakeDoc:
-            text_before_cursor = "ans(x) :- term"
-
         # Just ensure no exception is raised
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document("ans(x) :- term"), None))
         # May or may not return completions depending on Lark grammar state,
         # but should not crash
         assert isinstance(completions, list)
@@ -82,10 +72,7 @@ class TestNeuroLangReplCompleter:
         """Completer yields SQUALL keywords when no lark_completer is set."""
         completer = NeuroLangReplCompleter(squall_keywords=SQUALL_KEYWORDS)
 
-        class FakeDoc:
-            text_before_cursor = "ob"
-
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document("ob"), None))
         texts = [c.text for c in completions]
         assert "obtain" in texts
 
@@ -95,10 +82,7 @@ class TestNeuroLangReplCompleter:
             engine_predicates={"term", "study", "peak"}
         )
 
-        class FakeDoc:
-            text_before_cursor = "st"
-
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document("st"), None))
         texts = [c.text for c in completions]
         assert "study" in texts
         assert "term" not in texts  # doesn't start with "st"
@@ -109,13 +93,81 @@ class TestNeuroLangReplCompleter:
             engine_predicates={"term", "study"}
         )
 
-        class FakeDoc:
-            text_before_cursor = "12"
-
-        completions = list(completer.get_completions(FakeDoc(), None))
+        completions = list(completer.get_completions(Document("12"), None))
         texts = [c.text for c in completions]
         assert "term" not in texts
         assert "study" not in texts
+
+
+class TestSlashCommands:
+    """Tests for SLASH_COMMANDS constant, slash completion, and handling."""
+
+    @pytest.fixture
+    def completer(self):
+        try:
+            lark = LarkCompleter(COMPILED_GRAMMAR)
+        except Exception:
+            lark = None
+        return NeuroLangReplCompleter(lark_completer=lark)
+
+    def test_slash_commands_constant(self):
+        """SLASH_COMMANDS dict contains all expected commands."""
+        assert "/rewritten" in SLASH_COMMANDS
+        assert "/datalog" in SLASH_COMMANDS
+        assert "/help" in SLASH_COMMANDS
+
+    def test_slash_completer(self, completer):
+        """Completer yields slash commands when text starts with /."""
+        completions = list(completer.get_completions(Document("/"), None))
+        commands = [c.text for c in completions]
+        assert "/rewritten" in commands
+        assert "/datalog" in commands
+        assert "/help" in commands
+
+    def test_slash_completer_partial(self, completer):
+        """Completer filters slash commands by prefix."""
+        completions = list(completer.get_completions(Document("/re"), None))
+        commands = [c.text for c in completions]
+        assert "/rewritten" in commands
+        assert "/datalog" not in commands
+        assert "/help" not in commands
+
+    def test_slash_completer_datalog_prefix(self, completer):
+        """Completer filters /datalog with /da prefix."""
+        completions = list(completer.get_completions(Document("/da"), None))
+        commands = [c.text for c in completions]
+        assert "/datalog" in commands
+        assert "/rewritten" not in commands
+
+    def test_slash_completer_doesnt_leak_to_plain_text(self, completer):
+        """Slash commands should NOT appear when text doesn't start with /."""
+        completions = list(completer.get_completions(Document("abc"), None))
+        texts = [c.text for c in completions]
+        assert "/rewritten" not in texts
+        assert "/datalog" not in texts
+        assert "/help" not in texts
+
+    def test_slash_completer_doesnt_leak_to_dot_text(self, completer):
+        """Slash commands should NOT appear when text starts with ."""
+        completions = list(completer.get_completions(Document(".help"), None))
+        texts = [c.text for c in completions]
+        assert "/help" not in texts
+
+    def test_slash_handle_unknown_prints_warning(self):
+        """Unknown slash command prints a warning (uses _console.print)."""
+        app = InteractiveTuiApp.__new__(InteractiveTuiApp)
+        # Verify _handle_slash_command exists and can be called
+        assert hasattr(app, "_handle_slash_command")
+        # It should return True (session continues) even for unknown cmds
+        result = app._handle_slash_command("/unknown")
+        assert result is True
+
+    def test_slash_help_does_not_crash(self):
+        """/help handler should exist and not crash."""
+        app = InteractiveTuiApp(engine_name="neurosynth")
+        assert hasattr(app, "_cmd_help")
+        # Should not raise
+        app._cmd_help()
 
     def test_mode_switch_rebuilds_completer(self):
         """InteractiveTuiApp._rebuild_completer switches between LALR and SQUALL."""

--- a/neurolang/utils/tests/test_interactive_tui.py
+++ b/neurolang/utils/tests/test_interactive_tui.py
@@ -413,3 +413,51 @@ class TestInteractiveTuiAppPrompt:
         assert prompt.endswith("> ")
         assert "nl(" in prompt
         assert ")" in prompt
+
+
+
+class TestInteractiveTuiAppIdb:
+    @pytest.fixture
+    def app_with_engine(self):
+        from neurolang.frontend import NeurolangPDL
+
+        nl = NeurolangPDL()
+        nl.add_tuple_set([("alice",), ("bob",)], name="person")
+        nl.add_tuple_set([("alice",)], name="plays")
+        nl.program_ir.push_scope()
+        nl.execute_datalog_program("active(x) :- person(x), plays(x).")
+
+        app = InteractiveTuiApp.__new__(InteractiveTuiApp)
+        app._nl = nl
+        app._engine_built = True
+        app.engine_name = "test"
+        return app
+
+    def test_idb_lists_session_predicate(self, app_with_engine, capsys):
+        app_with_engine._cmd_idb()
+        captured = capsys.readouterr()
+        assert "active" in captured.out
+
+    def test_clear_all_removes_session_idb(self, app_with_engine, capsys):
+        app_with_engine._cmd_clear("")
+        captured = capsys.readouterr()
+        assert "cleared" in captured.out
+        assert "active" not in [
+            sym.name for sym in app_with_engine._nl.program_ir.intensional_database()
+        ]
+
+    def test_clear_specific_removes_predicate(self, app_with_engine, capsys):
+        app_with_engine._cmd_clear("active")
+        captured = capsys.readouterr()
+        assert "active" in captured.out
+        assert "active" not in [
+            sym.name for sym in app_with_engine._nl.program_ir.intensional_database()
+        ]
+
+    def test_clear_specific_rejects_engine_predicate(self, app_with_engine, capsys):
+        app_with_engine._cmd_clear("person")
+        captured = capsys.readouterr()
+        assert "engine" in captured.out.lower() or "not an IDB predicate" in captured.out
+        assert "person" in [
+            sym.name for sym in app_with_engine._nl.program_ir.symbol_table
+        ]

--- a/neurolang/utils/tests/test_interactive_tui.py
+++ b/neurolang/utils/tests/test_interactive_tui.py
@@ -12,6 +12,7 @@ from neurolang.utils.interactive_tui import (
     InteractiveTuiApp,
     NeuroLangReplCompleter,
     DOT_COMMANDS,
+    SQUALL_KEYWORDS,
 )
 from neurolang.utils.interactive_parsing import LarkCompleter
 from neurolang.frontend.datalog.standard_syntax import COMPILED_GRAMMAR
@@ -35,7 +36,7 @@ class TestNeuroLangReplCompleter:
             lark = LarkCompleter(COMPILED_GRAMMAR)
         except Exception:
             lark = None
-        return NeuroLangReplCompleter(lark)
+        return NeuroLangReplCompleter(lark_completer=lark)
 
     def test_dot_command_completions(self, completer):
         """Dot commands should complete partially typed commands."""
@@ -76,6 +77,63 @@ class TestNeuroLangReplCompleter:
         # May or may not return completions depending on Lark grammar state,
         # but should not crash
         assert isinstance(completions, list)
+
+    def test_squall_keywords(self):
+        """Completer yields SQUALL keywords when no lark_completer is set."""
+        completer = NeuroLangReplCompleter(squall_keywords=SQUALL_KEYWORDS)
+
+        class FakeDoc:
+            text_before_cursor = "ob"
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        texts = [c.text for c in completions]
+        assert "obtain" in texts
+
+    def test_engine_predicates(self):
+        """Completer yields engine predicate names."""
+        completer = NeuroLangReplCompleter(
+            engine_predicates={"term", "study", "peak"}
+        )
+
+        class FakeDoc:
+            text_before_cursor = "st"
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        texts = [c.text for c in completions]
+        assert "study" in texts
+        assert "term" not in texts  # doesn't start with "st"
+
+    def test_predicates_skipped_for_non_identifiers(self):
+        """Predicate completion should not fire for non-identifier prefixes."""
+        completer = NeuroLangReplCompleter(
+            engine_predicates={"term", "study"}
+        )
+
+        class FakeDoc:
+            text_before_cursor = "12"
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        texts = [c.text for c in completions]
+        assert "term" not in texts
+        assert "study" not in texts
+
+    def test_mode_switch_rebuilds_completer(self):
+        """InteractiveTuiApp._rebuild_completer switches between LALR and SQUALL."""
+        app = InteractiveTuiApp(engine_name="neurosynth", squall_mode=False)
+        assert app._completer is not None
+        # Datalog mode should have a lark completer
+        assert app._completer._lark is not None
+
+        # Switch to SQUALL
+        app._cmd_mode("squall")
+        assert app.squall_mode is True
+        # In SQUALL mode, lark should be None
+        assert app._completer._lark is None
+
+        # Switch back to Datalog
+        app._cmd_mode("datalog")
+        assert app.squall_mode is False
+        assert app._completer._lark is not None
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.scripts]
+neurolang-query = "neurolang.utils.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "sqlalchemy>=1.4",
     "siibra>=1.0.1a15",
     "pyyaml>=6.0",
+    "prompt-toolkit>=3.0.52",
+    "rich>=15.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ ras-polars = [
     "pyarrow",
 ]
 
+tui = [
+    "prompt-toolkit>=3.0",
+    "rich>=13.0",
+]
+
 doc = [
     "sphinx>=7.0",
     "pydata-sphinx-theme>=0.15",


### PR DESCRIPTION
## Summary

Adds `--interactive` / `-i` flag to `neurolang-query` launching a prompt_toolkit-based TUI REPL.

### Features
- **Grammar-aware autocomplete**: Lark LALR interactive parser wraps existing `LarkCompleter` for Datalog syntax
- **Rich table rendering**: query result DataFrames displayed as bordered rich tables
- **Dot-commands**: `.help`, `.engines`, `.sets`, `.predicates`, `.save`, `.view`, `.mode`, `.quit`
- **NIfTI support**: `.save path.nii` converts voxel-coordinate results to NIfTI volumes; `.view path.nii` opens via nilearn
- **Multi-line editing**: Alt+Enter inserts newline
- **Persistent command history**: stored in `~/.neurolang_query_history`
- **Mode switching**: `.mode datalog` / `.mode squall`

### Files changed
- `neurolang/utils/cli.py` — added `--interactive` / `-i` argument
- `neurolang/utils/interactive_tui.py` — new module: REPL with autocomplete, rich output, NIfTI save/view
- `neurolang/utils/tests/test_interactive_tui.py` — 29 tests covering completer, table render, DataFrame formatting, NIfTI conversion

### Notes
- Autocomplete uses the existing `LarkCompleter` (LALR only). Currently works for Datalog mode only — SQUALL mode uses a different grammar (Earley/standard parser) and won't have grammar-aware completion until a SQUALL `LarkCompleter` is implemented.
- Requires `prompt_toolkit` and `rich` (already installed in the dev environment).