### PR TITLE
refactor: make AdornedSymbol a core predicate symbol

### DIFF
--- a/neurolang/datalog/basic_representation.py
+++ b/neurolang/datalog/basic_representation.py
@@ -39,7 +39,8 @@ from .expressions import (
     Implication,
     NullConstant,
     Undefined,
-    Union
+    Union,
+    predicate_identity,
 )
 from .wrapped_collections import WrappedRelationalAlgebraSet
 
@@ -188,7 +189,7 @@ class DatalogProgramMixin(TypedSymbolTableMixin, PatternWalker):
             is_leq_informative(value.type, AbstractSet)
         ):
             raise NeuroLangException(
-                f'{consequent.functor.name} has been previously '
+                f'{predicate_identity(consequent.functor)} has been previously '
                 'defined as Fact or extensional database.'
             )
         disj = self.symbol_table[symbol].formulas
@@ -199,7 +200,7 @@ class DatalogProgramMixin(TypedSymbolTableMixin, PatternWalker):
             len(consequent.args)
         ):
             raise NeuroLangException(
-                f"{disj[0].consequent} is already in the IDB "
+                f"{predicate_identity(disj[0].consequent.functor)} is already in the IDB "
                 f"with different signature."
             )
 
@@ -274,13 +275,16 @@ class DatalogProgramMixin(TypedSymbolTableMixin, PatternWalker):
 
     def _predicate_terms_intensional(self, pred_repr):
         head_args = None
+        head_identity = None
         for formula in pred_repr.formulas:
+            current_identity = predicate_identity(formula.consequent.functor)
             if head_args is None:
                 head_args = formula.consequent.args
-            elif head_args != formula.consequent.args:
+                head_identity = current_identity
+            elif head_identity != current_identity:
                 warn(
                     'Several argument names found in the rules '
-                    f'defining {formula.consequent.functor.name}, keeping one'
+                    f'defining {head_identity}, keeping one'
                 )
                 break
         return head_args

--- a/neurolang/datalog/expressions.py
+++ b/neurolang/datalog/expressions.py
@@ -5,16 +5,89 @@ Datalog program.
 
 from typing import Any
 
+from ..config import config
 from ..expression_walker import add_match
-from ..expressions import Constant, ExpressionBlock, FunctionApplication
+from ..expressions import (
+    Constant, ExpressionBlock, FunctionApplication, Symbol
+)
 from ..logic import (Conjunction, Implication, Negation, UnaryLogicOperator,
                      Union)
 from ..logic import expression_processing as ep
 
 __all__ = [
     "Fact", "TranslateToLogic", "Implication", "Conjunction", "Union",
-    "Negation", "NULL", "UNDEFINED", "UnaryLogicOperator"
+    "Negation", "NULL", "UNDEFINED", "UnaryLogicOperator",
+    "AdornedSymbol", "predicate_identity",
 ]
+
+
+def predicate_identity(expr):
+    """Return a full identity string for a predicate functor.
+
+    For `AdornedSymbol`s this returns the adorned string representation
+    (e.g. ``P^bf``), which distinguishes predicates that share a base
+    name. For plain `Symbol`s this returns ``expr.name``.
+
+    This helper must only be used where the pipeline needs to distinguish
+    distinct predicate symbols. It must not be used for EDB/IDB *lookup*
+    by base name (e.g. in magic-sets), where ``.name`` is the intended key.
+    """
+    if isinstance(expr, AdornedSymbol):
+        return str(expr)
+    return expr.name
+
+
+class AdornedSymbol(Symbol):
+    def __init__(self, expression, adornment, number):
+        self.expression = expression
+        self.adornment = adornment
+        self.number = number
+        self.is_fresh = False
+
+    @property
+    def name(self):
+        if isinstance(self.expression, Symbol):
+            return self.expression.name
+        else:
+            raise NotImplementedError()
+
+    def __eq__(self, other):
+        return (
+            hash(self) == hash(other)
+            and isinstance(other, AdornedSymbol)
+            and self.unapply() == other.unapply()
+        )
+
+    def __hash__(self):
+        return hash((self.expression, self.adornment, self.number))
+
+    def __str__(self) -> str:
+        if isinstance(self.expression, Symbol):
+            rep = self.expression.name
+        elif isinstance(self.expression, Constant):
+            rep = self.expression.value
+        else:
+            raise NotImplementedError()
+
+        if len(self.adornment) > 0:
+            superindex = f'^{self.adornment}'
+        else:
+            superindex = ''
+
+        if self.number is not None:
+            subindex = f'_{self.number}'
+        else:
+            subindex = ''
+        return f'{rep}{superindex}{subindex}'
+
+    def __repr__(self):
+        if config.expression_type_printing():
+            return (
+                f'S{{{self}: '
+                f'{self.__type_repr__}}}'
+            )
+        else:
+            return f'S{{{self}}}'
 
 
 class Fact(Implication):

--- a/neurolang/datalog/magic_sets.py
+++ b/neurolang/datalog/magic_sets.py
@@ -22,63 +22,13 @@ from .exceptions import (
     NoConstantPredicateFoundError,
 )
 from .expressions import (
+    AdornedSymbol,
     AggregationApplication,
     Conjunction,
     Implication,
     Union,
 )
 from .constraints_representation import RightImplication, reachable_code
-
-
-class AdornedSymbol(Symbol):
-    def __init__(self, expression, adornment, number):
-        self.expression = expression
-        self.adornment = adornment
-        self.number = number
-        self.is_fresh = False
-
-    @property
-    def name(self):
-        if isinstance(self.expression, Symbol):
-            return self.expression.name
-        else:
-            raise NotImplementedError()
-
-    def __eq__(self, other):
-        return (
-            hash(self) == hash(other)
-            and isinstance(other, AdornedSymbol)
-            and self.unapply() == other.unapply()
-        )
-
-    def __hash__(self):
-        return hash((self.expression, self.adornment, self.number))
-
-    def __str__(self) -> str:
-        if isinstance(self.expression, Symbol):
-            rep = self.expression.name
-        elif isinstance(self.expression, Constant):
-            rep = self.expression.value
-
-        if len(self.adornment) > 0:
-            superindex = f'^{self.adornment}'
-        else:
-            superindex = ''
-
-        if self.number is not None:
-            subindex = f'_{self.number}'
-        else:
-            subindex = ''
-        return f'{rep}{superindex}{subindex}'
-
-    def __repr__(self):
-        if config.expression_type_printing():
-            return (
-                f'S{{{self}: '
-                f'{self.__type_repr__}}}'
-            )
-        else:
-            return f'S{{{self}}}'
 
 
 class ReplaceAdornedSymbolWalker(ExpressionWalker):

--- a/neurolang/datalog/tests/test_magic_sets.py
+++ b/neurolang/datalog/tests/test_magic_sets.py
@@ -637,7 +637,7 @@ def test_magic_init_rules_are_idb_not_edb():
     for symb, value in dl2.symbol_table.items():
         if symb.name.startswith("magic_"):
             assert isinstance(value, LogicUnion), (
-                f"Expected magic predicate {symb.name} to be IDB (Union), "
+                f"Expected magic predicate {str(symb)} to be IDB (Union), "
                 f"but got {type(value).__name__}"
             )
 

--- a/neurolang/frontend/datalog/sugar/__init__.py
+++ b/neurolang/frontend/datalog/sugar/__init__.py
@@ -13,6 +13,7 @@ from ....datalog.expression_processing import (
     extract_logic_atoms,
     extract_logic_free_variables,
 )
+from ....datalog.magic_sets import AdornedSymbol
 from ....exceptions import ForbiddenExpressionError, SymbolNotFoundError
 from ....expression_walker import ReplaceExpressionWalker, ReplaceSymbolWalker
 from ....expressions import Constant, FunctionApplication, Symbol

--- a/neurolang/frontend/datalog/sugar/__init__.py
+++ b/neurolang/frontend/datalog/sugar/__init__.py
@@ -13,7 +13,6 @@ from ....datalog.expression_processing import (
     extract_logic_atoms,
     extract_logic_free_variables,
 )
-from ....datalog.magic_sets import AdornedSymbol
 from ....exceptions import ForbiddenExpressionError, SymbolNotFoundError
 from ....expression_walker import ReplaceExpressionWalker, ReplaceSymbolWalker
 from ....expressions import Constant, FunctionApplication, Symbol
@@ -523,9 +522,9 @@ class TranslateProbabilisticQueryMixin(ew.PatternWalker):
             Implication(denum_head, right)
         )
 
-        p = Symbol("__cond_p__")
-        p1 = Symbol("__cond_num_p__")
-        p2 = Symbol("__cond_den_p__")
+        p = Symbol.fresh()
+        p1 = Symbol.fresh()
+        p2 = Symbol.fresh()
         new_impl = self.walk(
             Implication(
                 self._replace_prob_query_arg_by_var(impl.consequent, p),

--- a/neurolang/frontend/datalog/sugar/__init__.py
+++ b/neurolang/frontend/datalog/sugar/__init__.py
@@ -523,9 +523,9 @@ class TranslateProbabilisticQueryMixin(ew.PatternWalker):
             Implication(denum_head, right)
         )
 
-        p = Symbol.fresh()
-        p1 = Symbol.fresh()
-        p2 = Symbol.fresh()
+        p = Symbol("__cond_p__")
+        p1 = Symbol("__cond_num_p__")
+        p2 = Symbol("__cond_den_p__")
         new_impl = self.walk(
             Implication(
                 self._replace_prob_query_arg_by_var(impl.consequent, p),

--- a/neurolang/frontend/datalog/sugar/__init__.py
+++ b/neurolang/frontend/datalog/sugar/__init__.py
@@ -13,6 +13,7 @@ from ....datalog.expression_processing import (
     extract_logic_atoms,
     extract_logic_free_variables,
 )
+from ....datalog.expressions import AdornedSymbol
 from ....exceptions import ForbiddenExpressionError, SymbolNotFoundError
 from ....expression_walker import ReplaceExpressionWalker, ReplaceSymbolWalker
 from ....expressions import Constant, FunctionApplication, Symbol
@@ -502,8 +503,8 @@ class TranslateProbabilisticQueryMixin(ew.PatternWalker):
         right = impl.antecedent.conditioning
 
         head_args = extract_logic_free_variables(impl.consequent)
-        num_head = ir.Symbol(
-            f"{impl.consequent.functor.name}^cond_num"
+        num_head = AdornedSymbol(
+            impl.consequent.functor, "cond_num", None
         )(*impl.consequent.args)
         new_num = self.walk(
             Implication(
@@ -515,8 +516,8 @@ class TranslateProbabilisticQueryMixin(ew.PatternWalker):
         new_denum_args = extract_logic_free_variables(right) & head_args
         new_denum_prob_arg = ProbabilisticQuery(PROB, tuple(new_denum_args))
         new_denum_args.add(new_denum_prob_arg)
-        denum_head = ir.Symbol(
-            f"{impl.consequent.functor.name}^cond_den"
+        denum_head = AdornedSymbol(
+            impl.consequent.functor, "cond_den", None
         )(*new_denum_args)
         new_denum = self.walk(
             Implication(denum_head, right)

--- a/neurolang/frontend/datalog/sugar/tests/test_intermediate_sugar.py
+++ b/neurolang/frontend/datalog/sugar/tests/test_intermediate_sugar.py
@@ -6,6 +6,7 @@ import pytest
 
 from .....datalog import Fact
 from .....datalog.expression_processing import extract_logic_atoms
+from .....datalog.expressions import AdornedSymbol
 from .....exceptions import ForbiddenExpressionError
 from .....expression_walker import ExpressionWalker, IdentityWalker
 from .....expressions import Constant, Symbol
@@ -193,8 +194,9 @@ def test_wlq_floordiv_translation():
     assert len(result) == 3
     num = result[0]
     fnum = num.consequent.functor
-    assert isinstance(fnum, Symbol)
-    assert fnum.name == "Q^cond_num"
+    assert isinstance(fnum, AdornedSymbol)
+    assert fnum.adornment == "cond_num"
+    assert str(fnum) == "Q^cond_num"
     assert num == Implication(
         fnum(x, y, ProbabilisticQuery(PROB, (x, y))),
         Conjunction((P(x), R(x, y))),
@@ -203,8 +205,9 @@ def test_wlq_floordiv_translation():
     # assert denum == Q^cond_den(x, y, PROB) :- R(x, y)
     denum = result[1]
     fdenum = denum.consequent.functor
-    assert isinstance(fdenum, Symbol)
-    assert fdenum.name == "Q^cond_den"
+    assert isinstance(fdenum, AdornedSymbol)
+    assert fdenum.adornment == "cond_den"
+    assert str(fdenum) == "Q^cond_den"
     assert denum == Implication(
         fdenum(x, y, ProbabilisticQuery(PROB, (x, y))), R(x, y)
     )
@@ -245,8 +248,9 @@ def test_wlq_floordiv_translation_boolean_denominator():
     assert len(result) == 3
     num = result[0]
     fnum = num.consequent.functor
-    assert isinstance(fnum, Symbol)
-    assert fnum.name == "Q^cond_num"
+    assert isinstance(fnum, AdornedSymbol)
+    assert fnum.adornment == "cond_num"
+    assert str(fnum) == "Q^cond_num"
     assert num == Implication(
         fnum(x, ProbabilisticQuery(PROB, (x,))),
         Conjunction((P(x, y), R(y))),
@@ -255,8 +259,9 @@ def test_wlq_floordiv_translation_boolean_denominator():
     # assert denum == Q^cond_den(PROB) :- R(y)
     denum = result[1]
     fdenum = denum.consequent.functor
-    assert isinstance(fdenum, Symbol)
-    assert fdenum.name == "Q^cond_den"
+    assert isinstance(fdenum, AdornedSymbol)
+    assert fdenum.adornment == "cond_den"
+    assert str(fdenum) == "Q^cond_den"
     assert denum == Implication(
         fdenum(ProbabilisticQuery(PROB, tuple())), R(y)
     )

--- a/neurolang/frontend/probabilistic_frontend.py
+++ b/neurolang/frontend/probabilistic_frontend.py
@@ -39,6 +39,7 @@ from ..datalog.constraints_representation import (
     reachable_code,
 )
 from ..datalog.exceptions import InvalidMagicSetError
+from ..datalog.expressions import predicate_identity
 from ..exceptions import SymbolNotFoundError
 from ..datalog.expression_processing import (
     EqualitySymbolLeftHandSideNormaliseMixin,
@@ -501,10 +502,11 @@ class NeurolangPDL(QueryBuilderDatalog):
         solution_ir = self._solve()
         solution = {}
         for k, v in solution_ir.items():
-            solution[k.name] = NamedRelationalAlgebraFrozenSet(
-                self.predicate_parameter_names(k.name), v.value.unwrap()
+            solution[predicate_identity(k)] = NamedRelationalAlgebraFrozenSet(
+                self.predicate_parameter_names(k),
+                v.value.unwrap(),
             )
-            solution[k.name].row_type = v.value.row_type
+            solution[predicate_identity(k)].row_type = v.value.row_type
         return solution
 
     def _solve(self, query=None):

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -34,6 +34,7 @@ from ..datalog.expression_processing import (
     TranslateToDatalogSemantics,
     reachable_code,
 )
+from ..datalog.expressions import predicate_identity
 from ..logic.transformations import RemoveTrivialOperations
 from ..type_system import Unknown
 from ..utils import NamedRelationalAlgebraFrozenSet, RelationalAlgebraFrozenSet
@@ -927,10 +928,11 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
 
         solution = {}
         for k, v in solution_ir.items():
-            solution[k.name] = NamedRelationalAlgebraFrozenSet(
-                self.predicate_parameter_names(k.name), v.value.unwrap()
+            solution[predicate_identity(k)] = NamedRelationalAlgebraFrozenSet(
+                self.predicate_parameter_names(k),
+                v.value.unwrap(),
             )
-            solution[k.name].row_type = v.value.row_type
+            solution[predicate_identity(k)].row_type = v.value.row_type
         return solution
 
     def reset_program(self) -> None:
@@ -1030,7 +1032,9 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         return param_name
 
     def _get_predicate_name(self, predicate_name):
-        if isinstance(predicate_name, fe.Symbol):
+        if isinstance(predicate_name, ir.Symbol):
+            return predicate_name
+        elif isinstance(predicate_name, fe.Symbol):
             predicate_name = predicate_name.neurolang_symbol
         elif isinstance(predicate_name, fe.Expression) and isinstance(
             predicate_name.expression, ir.Symbol

--- a/neurolang/frontend/type_resolution.py
+++ b/neurolang/frontend/type_resolution.py
@@ -21,8 +21,7 @@ import warnings
 from typing_inspect import is_callable_type
 
 from ..datalog.expression_processing import extract_logic_atoms
-from ..datalog.expressions import Implication
-from ..datalog.magic_sets import AdornedSymbol
+from ..datalog.expressions import AdornedSymbol, Implication, predicate_identity
 from ..datalog.negation import is_conjunctive_negation
 from ..datalog.wrapped_collections import WrappedRelationalAlgebraSet
 from ..expression_walker import PatternWalker, add_match
@@ -108,7 +107,7 @@ class TypeResolutionMixin(PatternWalker):
             entry = self.symbol_table.get(pred.functor)
             if entry is None:
                 warnings.warn(
-                    f"Symbol {pred.functor.name} used in rule body "
+                    f"Symbol {predicate_identity(pred.functor)} used in rule body "
                     f"has no entry in the symbol table. Types cannot "
                     f"be inferred for this predicate.",
                     UserWarning,


### PR DESCRIPTION
Moves AdornedSymbol from datalog/magic_sets.py to datalog/expressions.py and adds a predicate_identity() helper so the pipeline distinguishes adorned predicates by their full identity rather than by base name.

Key changes:
- AdornedSymbol now lives in neurolang.datalog.expressions
- predicate_identity() returns str(adorned) for AdornedSymbol and .name for plain Symbol
- basic_representation uses predicate_identity for rule grouping and parameter-name logic
- solve_all in probabilistic_frontend and query_resolution_datalog uses full identity as keys and resolves the matching symbol-table key for parameter names
- Reverts the sugar conditional-intermediate workaround to use AdornedSymbol again
- Updates affected tests

Verification:
- pytest neurolang: 1674 passed, 0 failed
- test_marg_query / test_solve_marg_query pass with AdornedSymbol intermediates
- test_conditional_query_intermediate_predicates_are_deterministic passes