### PR TITLE
fix: remove duplicate SQUALL rules in --show-rewritten output and sort topologically

### DIFF
--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -31,6 +31,7 @@ from ..datalog.constraints_representation import RightImplication
 from ..datalog.exceptions import InvalidMagicSetError
 from ..datalog.expression_processing import (
     remove_conjunction_duplicates,
+    stratify,
     TranslateToDatalogSemantics,
     reachable_code,
 )
@@ -163,8 +164,12 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         printer = DatalogPrettyPrinter()
         print(printer.walk(query_expression))
         if reachable_rules is not None:
-            for rule in reachable_rules.formulas:
-                print(printer.walk(rule))
+            strata, _ = stratify(reachable_rules, self.program_ir)
+            query_functor = query_expression.consequent.functor
+            for stratum in strata:
+                for rule in stratum:
+                    if rule.consequent.functor != query_functor:
+                        print(printer.walk(rule))
         print()
 
     def _handle_rewritten_output(
@@ -446,13 +451,13 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
 
         self.program_ir.push_scope()
         try:
-            for rule in rules_and_choice_defs:
-                if isinstance(rule, (EquiprobableChoiceDef, WeightedChoiceDef)):
-                    continue  # already registered in global scope
-                try:
-                    self.program_ir.walk(rule)
-                except ForbiddenDisjunctionError:
-                    pass
+            # Rules are already walked into the global scope by
+            # execute_squall_program; re-walking them here duplicates
+            # intentional rules and makes --show-rewritten output contain
+            # repeated rules (fresh probability variables defeat repr-based
+            # deduplication). Choice definitions are already registered
+            # globally as well, so nothing from rules_and_choice_defs needs
+            # to be re-added in this per-query scope.
             self.program_ir.walk(query_impl)
             fe_pred = fe.Expression(self, h(*head_vars))
             fe_head = tuple(


### PR DESCRIPTION
## Summary

Three fixes to `neurolang/frontend/query_resolution_datalog.py` that eliminate duplicate rules in `--show-rewritten` (`-R`) output and sort rules topologically.

## Changes

1. **Stop re-walking SQUALL rules per query** — `_execute_single_squall_query` was re-walking all `define as` rules into a per-query scope, even though `execute_squall_program` already walked them globally. This created duplicate IDB entries with different fresh probability variables, defeating `repr`-based deduplication.

2. **Filter query rule from reachable rules display** — `_print_rewritten_program` now skips the original query rule (identified by consequent functor) when iterating reachable rules, so the query is printed only once (as the magic-rewritten query) instead of twice.

3. **Topological sort for `-R` output** — uses the existing `stratify()` function to order reachable rules by dependency, so each rule appears after the predicates it depends on.

## Before

```
── rewritten program ──
s₂(s₀, s₁) :-
    label_reports(s₀, s₁)
...
label_reports(s₃, s₈) :-
    label_reports^cond_num(s₃, s₉),
    label_reports^cond_den(s10),
    s₈ = s₉ ÷ s10
label_reports(s₃, s11) :-
    label_reports^cond_num(s₃, s12),
    label_reports^cond_den(s13),
    s11 = s12 ÷ s13
s₂(s₀, s₁) :-
    label_reports(s₀, s₁)
```

## After

```
── rewritten program ──
s₂(s₀, s₁) :-
    label_reports(s₀, s₁)
schaefer_label(l) :-
    schaefer(l, r)
reports(s, i, j, k) :-
    peak_reported(i, j, k, s)
...
label_reports(s₃, s₈) :-
    label_reports^cond_num(s₃, s₉),
    label_reports^cond_den(s10),
    s₈ = s₉ ÷ s10
``"

## Testing

All 185 relevant tests pass (34 SQUALL PDL integration + 52 probabilistic frontend + 99 CLI tests), 2 skipped (same as baseline).